### PR TITLE
Add support for nested social media data in ItemModel

### DIFF
--- a/fixtures.sql
+++ b/fixtures.sql
@@ -80,7 +80,9 @@ $$
                ('Tag2', ARRAY ['Twitter', 'Facebook']::social_media_type[], 2);
 
         INSERT INTO social_media (title, item_id, external_id)
-        VALUES ('Facebook', 1, 100),
-               ('Twitter', 2, 20000);
+        VALUES ('YouTube', 1, 100),
+               ('Twitter', 2, 20000),
+               ('Pinterest', 1, 30000),
+               ('Twitter', 1, 40000);
     END
 $$;

--- a/src/code/models/ItemModel.cpp
+++ b/src/code/models/ItemModel.cpp
@@ -4,6 +4,7 @@
 #include "ShippingProfileModel.h"
 #include "BasketItemModel.h"
 #include "QuerySet.h"
+#include "SocialMediaModel.h"
 #include "StringUtils.h"
 #include "env.h"
 #include <fmt/core.h>
@@ -69,9 +70,14 @@ std::string ItemModel::sqlSelectOne(const BaseField *field,
         .functions(Function(
             fmt::format("json_agg(json_build_object({}) ORDER BY media.sort ASC)", MediaModel().fieldsJsonObject())));
 
+    QuerySet<SocialMediaModel> nets(0, SocialMediaModel::tableName, false);
+    nets.functions(Function(fmt::format("json_agg(json_build_object({}))", SocialMediaModel().fieldsJsonObject())))
+        .filter(&SocialMediaModel::Field::itemId, &BaseModel::Field::id);
+
     QuerySet<ItemModel> qsItem(tableName, true, true);
     qsItem.filter(field, std::move(value))
         .jsonFields(addExtraQuotes(fieldsJsonObject()))
+        .functions(Function(addExtraQuotes(fmt::format(R"( 'nets', COALESCE(({}), '[]'::json))", nets.buildSelect()))))
         .functions(
             Function(addExtraQuotes(fmt::format(R"( 'media', COALESCE(({}), '[]'::json))", qsMedia.buildSelect()))));
 

--- a/src/code/models/SocialMediaModel.cpp
+++ b/src/code/models/SocialMediaModel.cpp
@@ -25,8 +25,7 @@ std::string SocialMediaModel::sqlSelectList(const int page,
     auto qsCount = SocialMediaModel::qsCount();
     auto qsPage = SocialMediaModel::qsPage(page, limit);
     QuerySet<SocialMediaModel> qs(limit, "data");
-    qs.join<SocialMediaModel>()
-        .offset(fmt::format("((SELECT * FROM {}) - 1) * {}", qsPage.alias(), limit))
+    qs.offset(fmt::format("((SELECT * FROM {}) - 1) * {}", qsPage.alias(), limit))
         .only(allSetFields())
         .order_by(&BaseModel::Field::updatedAt, false)
         .functions(Function(fmt::format("format_social_url({}, {}::TEXT) as social_url",

--- a/tests/TestItem.h
+++ b/tests/TestItem.h
@@ -36,6 +36,26 @@ class ItemControllerTest : public BaseTestClass<ItemControllerTest, api::v1::Ite
         getOneValues["shipping_profile_id"] = 1;
         getOneValues["price"] = 100.0;
 
+        Json::Value nets;
+        Json::Value net1;
+        net1["id"] = 1;
+        net1["title"] = "YouTube";
+        net1["social_url"] = "https://www.youtube.com/watch?v=100";
+        nets.append(net1);
+
+        Json::Value net2;
+        net2["id"] = 3;
+        net2["title"] = "Pinterest";
+        net2["social_url"] = "https://pinterest.com/pin/30000";
+        nets.append(net2);
+
+        Json::Value net3;
+        net3["id"] = 4;
+        net3["title"] = "Twitter";
+        net3["social_url"] = "https://x.com/faithfishart/status/40000";
+        nets.append(net3);
+        getOneValues["nets"] = nets;
+
         // Set up the "media" array
         Json::Value media = Json::arrayValue;
         Json::Value mediaEntry1;
@@ -124,7 +144,6 @@ class ItemControllerTest : public BaseTestClass<ItemControllerTest, api::v1::Ite
 };
 
 TEST_F(ItemControllerTest, Create200) {
-
     testCreate200();
 }
 

--- a/tests/TestSocialMedia.h
+++ b/tests/TestSocialMedia.h
@@ -22,13 +22,13 @@ class SocialMediaControllerTest : public BaseTestClass<SocialMediaControllerTest
         getOneValues["external_id"] = "100";
         getOneValues["id"] = 1;
         getOneValues["item_id"] = 1;
-        getOneValues["social_url"] = "100";
-        getOneValues["title"] = "Facebook";
+        getOneValues["social_url"] = "https://www.youtube.com/watch?v=100";
+        getOneValues["title"] = "YouTube";
     }
 
     void setupGetListValues() override {
         getListValues["_page"] = 1;
-        getListValues["total"] = 2;
+        getListValues["total"] = 4;
 
         Json::Value data = Json::arrayValue;
 
@@ -36,8 +36,8 @@ class SocialMediaControllerTest : public BaseTestClass<SocialMediaControllerTest
         entry1["external_id"] = "100";
         entry1["id"] = 1;
         entry1["item_id"] = 1;
-        entry1["social_url"] = "100";
-        entry1["title"] = "Facebook";
+        entry1["social_url"] = "https://www.youtube.com/watch?v=100";
+        entry1["title"] = "YouTube";
 
         Json::Value entry2;
         entry2["external_id"] = "20000";
@@ -46,8 +46,24 @@ class SocialMediaControllerTest : public BaseTestClass<SocialMediaControllerTest
         entry2["social_url"] = "https://x.com/faithfishart/status/20000";
         entry2["title"] = "Twitter";
 
+        Json::Value entry3;
+        entry3["external_id"] = "30000";
+        entry3["id"] = 3;
+        entry3["item_id"] = 1;
+        entry3["social_url"] = "https://pinterest.com/pin/30000";
+        entry3["title"] = "Pinterest";
+
+        Json::Value entry4;
+        entry4["external_id"] = "40000";
+        entry4["id"] = 4;
+        entry4["item_id"] = 1;
+        entry4["social_url"] = "https://x.com/faithfishart/status/40000";
+        entry4["title"] = "Twitter";
+
         data.append(entry1);
         data.append(entry2);
+        data.append(entry3);
+        data.append(entry4);
 
         getListValues["data"] = data;
     }


### PR DESCRIPTION
Enhanced ItemModel to include associated social media data via a nested JSON structure. Updated queries, tests, and fixtures to reflect the inclusion of social media records and their corresponding fields. Simplified query logic in SocialMediaModel for better maintainability.