### PR TITLE
fix: replace decimal_for_cpp with std::string to fix cmake rebuild loop

### DIFF
--- a/cmake/dependencies.cmake
+++ b/cmake/dependencies.cmake
@@ -33,10 +33,6 @@ CPMAddPackage(NAME cpr VERSION 1.14.2 GITHUB_REPOSITORY libcpr/cpr GIT_TAG 1.14.
 # fmt
 CPMAddPackage(NAME fmt VERSION 12.1.0 GITHUB_REPOSITORY fmtlib/fmt GIT_TAG 12.1.0)
 
-# decimal_for_cpp (header-only)
-CPMAddPackage(NAME decimal_for_cpp GITHUB_REPOSITORY vpiotr/decimal_for_cpp GIT_TAG 599372e DOWNLOAD_ONLY YES)
-include_directories(${decimal_for_cpp_SOURCE_DIR}/include)
-
 # libuuid — system library, installed via uuid-dev in Dockerfile.build
 find_library(UUID_LIBRARY uuid)
 if(NOT UUID_LIBRARY)

--- a/src/code/models/BaseModel.h
+++ b/src/code/models/BaseModel.h
@@ -44,8 +44,7 @@ namespace api::v1 {
                                           std::vector<std::string>,
                                           std::string,
                                           std::nullopt_t,
-                                          std::chrono::time_point<std::chrono::system_clock>,
-                                          dec::decimal<2>>;
+                                          std::chrono::time_point<std::chrono::system_clock>>;
         using SetMapFieldTypes = std::vector<std::pair<const BaseField *, ValueVariant>>;
         [[nodiscard]] virtual std::string sqlInsertMultiple(const std::vector<T> &items);
         [[nodiscard]] virtual std::string sqlInsertSingle(const T &item);

--- a/src/code/models/BaseModel.inl
+++ b/src/code/models/BaseModel.inl
@@ -40,10 +40,6 @@ namespace api::v1 {
             return std::to_string(arg);
         } else if constexpr(std::is_same_v<Type, bool>) {
             return arg ? "true" : "false";
-        } else if constexpr(std::is_same_v<Type, dec::decimal<2>>) {
-            std::stringstream ss;
-            ss << arg;
-            return ss.str();
         } else if constexpr(std::is_same_v<Type, std::vector<std::string>>) {
             std::string data = "{";
             for(const auto &str: arg) {

--- a/src/code/models/BaseModelImpl.h
+++ b/src/code/models/BaseModelImpl.h
@@ -4,7 +4,6 @@
 #include <string>
 #include <json/value.h>
 #include <chrono>
-#include "decimal.h"
 #include "orm/QuerySet.h"
 #include "utils/TransparentStringHash.h"
 
@@ -41,10 +40,6 @@ namespace api::v1 {
             }
         } else if constexpr(std::is_same_v<VDecayed, std::string_view> || std::is_same_v<VDecayed, std::string>) {
             if(value.empty()) {
-                fields[fieldName] = fieldName + " is required";
-            }
-        } else if constexpr(std::is_same_v<VDecayed, dec::decimal<2>>) {
-            if(value == dec::decimal<2>(0)) {
                 fields[fieldName] = fieldName + " is required";
             }
         } else if constexpr(std::is_same_v<VDecayed, double>) {

--- a/src/code/models/BasketItemModel.h
+++ b/src/code/models/BasketItemModel.h
@@ -28,11 +28,11 @@ namespace api::v1 {
         int basketId{};
         int itemId{};
         int quantity = 1;
-        dec::decimal<2> price;
+        std::string price = "0";
 
         explicit BasketItemModel(const Json::Value &json) : BaseModel(json) {
             if(json.isMember(Field::price.getFieldName())) {
-                price = json[Field::price.getFieldName()].asDouble();
+                price = json[Field::price.getFieldName()].asString();
             }
             basketId = json[Field::basketId.getFieldName()].asInt();
             itemId = json[Field::itemId.getFieldName()].asInt();

--- a/src/code/models/FinancialDetailsModel.h
+++ b/src/code/models/FinancialDetailsModel.h
@@ -1,6 +1,5 @@
 #pragma once
 
-#include <decimal.h>
 #include "models/BaseModel.h"
 
 namespace api::v1 {
@@ -24,7 +23,7 @@ namespace api::v1 {
         };
 
         explicit FinancialDetailsModel(const Json::Value &json) : BaseModel(json) {
-            taxRate = json[Field::taxRate.getFieldName()].asDouble();
+            taxRate = json[Field::taxRate.getFieldName()].asString();
             gateway = json[Field::gateway.getFieldName()].asString();
             gatewayMerchantId = json[Field::gatewayMerchantId.getFieldName()].asString();
             merchantId = json[Field::merchantId.getFieldName()].asString();
@@ -37,7 +36,7 @@ namespace api::v1 {
             validateField(Field::merchantName.getFieldName(), merchantName, missingFields);
         }
 
-        dec::decimal<2> taxRate;
+        std::string taxRate;
         std::string gateway;
         std::string gatewayMerchantId;
         std::string merchantId;

--- a/src/code/models/ItemModel.h
+++ b/src/code/models/ItemModel.h
@@ -2,7 +2,6 @@
 
 #include <string>
 #include "models/BaseModel.h"
-#include "decimal.h"
 
 namespace api::v1 {
 
@@ -32,7 +31,7 @@ namespace api::v1 {
         std::string description;
         std::string slug;
         bool enabled = false;
-        dec::decimal<2> price;
+        std::string price;
         std::string metaDescription;
 
         explicit ItemModel(const Json::Value &json) : BaseModel(json) {
@@ -42,7 +41,7 @@ namespace api::v1 {
             slug = json[Field::slug.getFieldName()].asString();
             shippingProfileId = json[Field::shippingProfileId.getFieldName()].asInt();
             enabled = json[Field::enabled.getFieldName()].asBool();
-            price = json[Field::price.getFieldName()].asDouble();
+            price = json[Field::price.getFieldName()].asString();
 
             validateField(Field::title.getFieldName(), title, missingFields);
             validateField(Field::description.getFieldName(), description, missingFields);

--- a/src/code/models/OrderModel.h
+++ b/src/code/models/OrderModel.h
@@ -4,7 +4,6 @@
 #include <drogon/drogon.h>
 #include "models/BaseModel.h"
 #include "models/BasketModel.h"
-#include "decimal.h"
 
 struct OrderStatus {
     static inline std::string ordered = "Ordered";  // The item has been ordered by the customer.
@@ -52,10 +51,10 @@ namespace api::v1 {
 
         std::string status = OrderStatus::ordered;
         int basketId{};
-        dec::decimal<2> total{};
-        dec::decimal<2> totalExTaxes{};
-        dec::decimal<2> taxRate{};
-        dec::decimal<2> taxes{};
+        std::string total;
+        std::string totalExTaxes;
+        std::string taxRate;
+        std::string taxes;
         bool returned = false;
         int userId{};
         int addressId{};
@@ -63,10 +62,10 @@ namespace api::v1 {
 
         explicit OrderModel(const Json::Value &json) : BaseModel(json) {
             basketId = json[Field::basketId.getFieldName()].asInt();
-            total = json[Field::total.getFieldName()].asDouble();
-            totalExTaxes = json[Field::totalExTaxes.getFieldName()].asDouble();
-            taxRate = json[Field::taxRate.getFieldName()].asDouble();
-            taxes = json[Field::taxes.getFieldName()].asDouble();
+            total = json[Field::total.getFieldName()].asString();
+            totalExTaxes = json[Field::totalExTaxes.getFieldName()].asString();
+            taxRate = json[Field::taxRate.getFieldName()].asString();
+            taxes = json[Field::taxes.getFieldName()].asString();
             userId = json[Field::userId.getFieldName()].asInt();
             addressId = json[Field::addressId.getFieldName()].asInt();
             returned = json[Field::returned.getFieldName()].asBool();

--- a/src/code/models/ShippingProfileModel.cpp
+++ b/src/code/models/ShippingProfileModel.cpp
@@ -12,5 +12,5 @@ BaseModel<ShippingProfileModel>::SetMapFieldTypes ShippingProfileModel::getObjec
             {&Field::processingTime, processingTime},
             {&Field::countryId, countryId},
             {&Field::postalCode, postalCode},
-            {&Field::shippingUpgradeCost, shippingUpgradeCost}};
+            {&Field::shippingUpgradeCost, shippingUpgradeCost.empty() ? ValueVariant{std::nullopt} : ValueVariant{shippingUpgradeCost}}};
 }

--- a/src/code/models/ShippingProfileModel.h
+++ b/src/code/models/ShippingProfileModel.h
@@ -4,7 +4,6 @@
 #include <chrono>
 #include <drogon/drogon.h>
 #include "models/BaseModel.h"
-#include "decimal.h"
 
 namespace api::v1 {
     class ShippingProfileModel final : public BaseModel<ShippingProfileModel> {
@@ -30,14 +29,14 @@ namespace api::v1 {
         int processingTime{};
         int countryId{};
         std::string postalCode;
-        dec::decimal<2> shippingUpgradeCost;
+        std::string shippingUpgradeCost;
 
         explicit ShippingProfileModel(const Json::Value &json) : BaseModel(json) {
             title = json[Field::title.getFieldName()].asString();
             processingTime = json[Field::processingTime.getFieldName()].asInt();
             countryId = json[Field::countryId.getFieldName()].asInt();
             postalCode = json[Field::postalCode.getFieldName()].asString();
-            shippingUpgradeCost = json[Field::shippingUpgradeCost.getFieldName()].asDouble();
+            shippingUpgradeCost = json[Field::shippingUpgradeCost.getFieldName()].asString();
 
             validateField(Field::title.getFieldName(), title, missingFields);
             validateField(Field::processingTime.getFieldName(), processingTime, missingFields);


### PR DESCRIPTION
## Summary
- Removes the `decimal_for_cpp` CPM dependency (no versioned releases caused re-fetch on every cmake run)
- Replaces all `dec::decimal<2>` fields with `std::string`; PostgreSQL accepts quoted numeric literals for `DECIMAL` columns via implicit cast
- Optional fields default to `"0"` (`BasketItemModel.price`) or `NULL` (`ShippingProfileModel.shippingUpgradeCost`) to preserve prior behaviour

## Test plan
- [x] 157/157 tests pass (`ctest --preset ninja-debug -j1`)

Closes #79