### PR TITLE
fix: remove redundant tableName from BaseModel to fix S1117 shadowing

### DIFF
--- a/src/code/models/BaseModel.h
+++ b/src/code/models/BaseModel.h
@@ -10,8 +10,6 @@ namespace api::v1 {
     class BaseModel : public BaseModelImpl {
     public:
         using BaseModelImpl::BaseModelImpl;
-        static const inline std::string tableName;
-
         struct Field {
             static inline const auto id = BaseField("id", T::tableName);
             static inline const auto createdAt = BaseField("created_at", T::tableName);


### PR DESCRIPTION
## Summary
- Removed the empty `static const inline std::string tableName` declaration from `BaseModel<T>`
- All usages already access it via `T::tableName` through the CRTP pattern — the base declaration was an unused fallback that caused S1117 warnings across every model file
- No code changes required in derived models or ORM query generation

Closes #87