### PR TITLE
fix: remove dead try/catch blocks in FileTransferInfo to fix S1181

### DIFF
--- a/src/code/clients/FileTransferInfo.h
+++ b/src/code/clients/FileTransferInfo.h
@@ -68,47 +68,37 @@ namespace api::v1 {
         }
 
         [[nodiscard]] size_t getSize() const {
-            try {
-                std::ifstream file(fileName, std::ios::binary | std::ios::ate);
-                if(!file) {
-                    LOG_ERROR << "Failed to open file: " << fileName << " Error: " << std::strerror(errno);
-                    return 0;
-                }
-                return file.tellg();
-            } catch(const std::exception& e) {
-                LOG_ERROR << "Exception in getSize: " << e.what();
+            std::ifstream file(fileName, std::ios::binary | std::ios::ate);
+            if(!file) {
+                LOG_ERROR << "Failed to open file: " << fileName << " Error: " << std::strerror(errno);
                 return 0;
             }
+            return file.tellg();
         }
 
         [[nodiscard]] std::shared_ptr<std::vector<char>> getFileContent() const {
-            try {
-                std::ifstream file(fileName, std::ios::binary);
-                if(!file) {
-                    LOG_ERROR << "Failed to open file: " << fileName << " Error: " << std::strerror(errno);
-                    return nullptr;
-                }
-
-                file.seekg(0, std::ios::end);
-                std::streampos fileSize = file.tellg();
-                file.seekg(0, std::ios::beg);
-
-                if(fileSize > MAX_FILE_SIZE) {
-                    LOG_ERROR << "File too large: " << fileName << " Size: " << fileSize;
-                    return nullptr;
-                }
-
-                auto buffer = std::make_shared<std::vector<char>>(static_cast<size_t>(fileSize));
-                if(!file.read(buffer->data(), fileSize)) {
-                    LOG_ERROR << "Failed to read file: " << fileName << " Error: " << std::strerror(errno);
-                    return nullptr;
-                }
-
-                return buffer;
-            } catch(const std::exception& e) {
-                LOG_ERROR << "Exception in getFileContent: " << e.what();
+            std::ifstream file(fileName, std::ios::binary);
+            if(!file) {
+                LOG_ERROR << "Failed to open file: " << fileName << " Error: " << std::strerror(errno);
                 return nullptr;
             }
+
+            file.seekg(0, std::ios::end);
+            std::streampos fileSize = file.tellg();
+            file.seekg(0, std::ios::beg);
+
+            if(fileSize > MAX_FILE_SIZE) {
+                LOG_ERROR << "File too large: " << fileName << " Size: " << fileSize;
+                return nullptr;
+            }
+
+            auto buffer = std::make_shared<std::vector<char>>(static_cast<size_t>(fileSize));
+            if(!file.read(buffer->data(), fileSize)) {
+                LOG_ERROR << "Failed to read file: " << fileName << " Error: " << std::strerror(errno);
+                return nullptr;
+            }
+
+            return buffer;
         }
 
         [[nodiscard]] std::string getFileName() const {


### PR DESCRIPTION
## Summary
- Removed unreachable `catch(const std::exception&)` blocks from `getSize()` and `getFileContent()` in `FileTransferInfo.h`
- `std::ifstream` operations do not throw without an explicit exception mask — all failure conditions are already handled via early-return checks on stream state
- Fixes SonarCloud cpp:S1181 (catch a more specific exception) findings at lines 78 and 108

Note: the `catch(...)` in test helpers (`TestPinterestOAuth.h`, `TestSocialMedia.h`) is intentional — it must forward any exception type (including GTest assertion failures) to `promise->set_exception`. Those are not changed here.

Closes #88