### PR TITLE
fix: replace std::jthread with std::thread for detached work to fix S5962

### DIFF
--- a/src/code/controllers/PinterestOAuth.cpp
+++ b/src/code/controllers/PinterestOAuth.cpp
@@ -181,7 +181,7 @@ void PinterestOAuth::callback(const HttpRequestPtr &req,
     const auto callbackPtr = std::make_shared<std::function<void(const HttpResponsePtr &)>>(std::move(callback));
 
     // Run blocking CPR call off the event loop thread
-    std::jthread([callbackPtr, code]() {
+    std::thread([callbackPtr, code]() {
         exchangeTokenAndSave(callbackPtr, code);
     }).detach();
 }


### PR DESCRIPTION
## Summary
- Replaced `std::jthread(...).detach()` with `std::thread(...).detach()` in `PinterestOAuth::callback`
- `std::jthread` is designed for RAII auto-join and cooperative cancellation — using it with `.detach()` violates its intended semantics and triggers SonarCloud cpp:S5962
- `std::thread` is the correct type when explicitly fire-and-forgetting a blocking task off the event loop thread

Closes #89