### PR TITLE
feat: optional per-field size overrides for AiAnalyzeImage

### DIFF
--- a/src/code/controllers/AiAnalyzeImage.cpp
+++ b/src/code/controllers/AiAnalyzeImage.cpp
@@ -55,6 +55,47 @@ A single tag can be reused for multiple platforms (list every platform it suits 
 Tag titles must be a single CamelCase or PascalCase word without spaces or punctuation.
 Return strictly valid JSON. Do not wrap in code fences.)";
 
+    // Optional per-request character-count limits for the generated fields.
+    // A value of 0 means "not set" → fall back to the default prompt wording.
+    struct SizeOverrides {
+        int title = 0;
+        int description = 0;
+        int metaDescription = 0;
+
+        [[nodiscard]] bool any() const noexcept {
+            return title > 0 || description > 0 || metaDescription > 0;
+        }
+    };
+
+    // Reads an optional positive integer override from the body. Non-numeric or
+    // non-positive values are treated as unset (return 0).
+    int readSize(const Json::Value &body, const char *key) {
+        const Json::Value &v = body[key];
+        if(!v.isIntegral())
+            return 0;
+        const int n = v.asInt();
+        return n > 0 ? n : 0;
+    }
+
+    // Builds the override instruction appended to the prompt. Only lists fields
+    // that were actually set. Returns an empty string when nothing is overridden.
+    std::string sizeOverrideBlock(const SizeOverrides &sizes) {
+        if(!sizes.any())
+            return {};
+        std::string parts;
+        const auto add = [&parts](std::string_view name, int n) {
+            if(n <= 0)
+                return;
+            if(!parts.empty())
+                parts += "; ";
+            parts += fmt::format("{} max {} chars", name, n);
+        };
+        add("title", sizes.title);
+        add("description", sizes.description);
+        add("meta_description", sizes.metaDescription);
+        return fmt::format("\n\nField size overrides (use these exact limits, in characters): {}.", parts);
+    }
+
     Json::Value errorJson(const std::string &error, const std::string &detail = {}) {
         Json::Value json;
         json["error"] = error;
@@ -184,14 +225,16 @@ Return strictly valid JSON. Do not wrap in code fences.)";
 
     void runClaudeAndRespond(const std::shared_ptr<std::function<void(const HttpResponsePtr &)>> &callbackPtr,
                              TempDirGuard guard,
-                             const std::string &imagePath) {
+                             const std::string &imagePath,
+                             const SizeOverrides &sizes) {
         const std::string &dir = guard.dir();
 
         const std::string prompt = getEnv("CLAUDE_ANALYZE_IMAGE_PROMPT", std::string(DEFAULT_PROMPT).c_str());
         const std::string fullPrompt = fmt::format(
-            "{}\n\nUse the Read tool to load the image at {} and then analyze it. Return ONLY the JSON object — "
+            "{}{}\n\nUse the Read tool to load the image at {} and then analyze it. Return ONLY the JSON object — "
             "no prose, no markdown fences, no explanation.",
             prompt,
+            sizeOverrideBlock(sizes),
             imagePath);
 
         const std::string cmd =
@@ -260,6 +303,10 @@ void AiAnalyzeImage::analyze(const HttpRequestPtr &req, std::function<void(const
         return;
     }
 
+    const SizeOverrides sizes{.title = readSize(body, "title_size"),
+                              .description = readSize(body, "description_size"),
+                              .metaDescription = readSize(body, "meta_description_size")};
+
     const std::string decoded = Base64::Decode(image);
     if(decoded.empty()) {
         callback(makeError(k400BadRequest, "Failed to decode base64 image"));
@@ -279,7 +326,7 @@ void AiAnalyzeImage::analyze(const HttpRequestPtr &req, std::function<void(const
     // class members (in the header) so dynamic init in this TU also forces
     // HttpController<T>::registrator_ to initialize at startup.
     std::lock_guard lock(workerMutex);
-    workerThreads.emplace_back([callbackPtr, guard = std::move(temp.guard), path = temp.filePath]() mutable {
-        runClaudeAndRespond(callbackPtr, std::move(guard), path);
+    workerThreads.emplace_back([callbackPtr, guard = std::move(temp.guard), path = temp.filePath, sizes]() mutable {
+        runClaudeAndRespond(callbackPtr, std::move(guard), path, sizes);
     });
 }

--- a/tests/TestAiAnalyzeImage.h
+++ b/tests/TestAiAnalyzeImage.h
@@ -18,6 +18,7 @@
 class AiAnalyzeImageTest : public ::testing::Test {
 private:
     std::filesystem::path stubDir;
+    std::filesystem::path promptFile;
     std::string originalPath;
     api::v1::AiAnalyzeImage controller;
 
@@ -35,7 +36,11 @@ protected:
         stubDir = templ;
 
         const auto scriptPath = stubDir / "claude";
+        promptFile = stubDir / "prompt.txt";
+        // The stub records every argument it receives (the prompt is the last
+        // arg) so tests can assert what the controller asked claude to do.
         std::ofstream(scriptPath) << "#!/bin/sh\n"
+                                     "printf '%s\\n' \"$@\" > \"$STUB_CLAUDE_PROMPT_FILE\"\n"
                                      "if [ -n \"$STUB_CLAUDE_FAIL\" ]; then echo \"boom\" 1>&2; exit 1; fi\n"
                                      "if [ -n \"$STUB_CLAUDE_GARBAGE\" ]; then echo \"not json\"; exit 0; fi\n"
                                      "cat <<'EOF'\n"
@@ -48,6 +53,7 @@ protected:
         if(const char *p = std::getenv("PATH"))
             originalPath = p;
         setenv("PATH", fmt::format("{}:{}", stubDir.string(), originalPath).c_str(), 1);
+        setenv("STUB_CLAUDE_PROMPT_FILE", promptFile.c_str(), 1);
 
         unsetenv("STUB_CLAUDE_FAIL");
         unsetenv("STUB_CLAUDE_GARBAGE");
@@ -58,8 +64,18 @@ protected:
             setenv("PATH", originalPath.c_str(), 1);
         unsetenv("STUB_CLAUDE_FAIL");
         unsetenv("STUB_CLAUDE_GARBAGE");
+        unsetenv("STUB_CLAUDE_PROMPT_FILE");
         std::error_code ec;
         std::filesystem::remove_all(stubDir, ec);
+    }
+
+    // Returns the full argument list the stub claude was invoked with, including
+    // the prompt. Empty if claude was never called.
+    [[nodiscard]] std::string capturedPrompt() const {
+        std::ifstream in(promptFile);
+        if(!in)
+            return {};
+        return {std::istreambuf_iterator<char>(in), std::istreambuf_iterator<char>()};
     }
 
     static std::string sampleImageBase64() {
@@ -146,4 +162,62 @@ TEST_F(AiAnalyzeImageTest, ClaudeFails502) {
 TEST_F(AiAnalyzeImageTest, ClaudeBadJson502) {
     setenv("STUB_CLAUDE_GARBAGE", "1", 1);
     invoke(buildRequest(validBody()), expectStatusAndError(drogon::k502BadGateway, "Invalid JSON from claude"));
+}
+
+TEST_F(AiAnalyzeImageTest, NoSizeOverridesOmitsBlock) {
+    invoke(buildRequest(validBody()), [](const drogon::HttpResponsePtr &resp) {
+        EXPECT_EQ(resp->getStatusCode(), drogon::k200OK);
+    });
+    const std::string prompt = capturedPrompt();
+    EXPECT_FALSE(prompt.empty());
+    EXPECT_EQ(prompt.find("Field size overrides"), std::string::npos);
+}
+
+TEST_F(AiAnalyzeImageTest, DescriptionSizeOverrideInjected) {
+    Json::Value body = validBody();
+    body["description_size"] = 300;
+    invoke(buildRequest(body), [](const drogon::HttpResponsePtr &resp) {
+        EXPECT_EQ(resp->getStatusCode(), drogon::k200OK);
+    });
+    const std::string prompt = capturedPrompt();
+    EXPECT_NE(prompt.find("Field size overrides"), std::string::npos);
+    EXPECT_NE(prompt.find("description max 300 chars"), std::string::npos);
+    // Fields that were not overridden must not appear in the override block.
+    EXPECT_EQ(prompt.find("title max"), std::string::npos);
+    EXPECT_EQ(prompt.find("meta_description max"), std::string::npos);
+}
+
+TEST_F(AiAnalyzeImageTest, AllSizeOverridesInjected) {
+    Json::Value body = validBody();
+    body["title_size"] = 60;
+    body["description_size"] = 300;
+    body["meta_description_size"] = 200;
+    invoke(buildRequest(body), [](const drogon::HttpResponsePtr &resp) {
+        EXPECT_EQ(resp->getStatusCode(), drogon::k200OK);
+    });
+    const std::string prompt = capturedPrompt();
+    EXPECT_NE(prompt.find("title max 60 chars"), std::string::npos);
+    EXPECT_NE(prompt.find("description max 300 chars"), std::string::npos);
+    EXPECT_NE(prompt.find("meta_description max 200 chars"), std::string::npos);
+}
+
+TEST_F(AiAnalyzeImageTest, NonPositiveSizeOverridesIgnored) {
+    Json::Value body = validBody();
+    body["title_size"] = 0;
+    body["description_size"] = -10;
+    invoke(buildRequest(body), [](const drogon::HttpResponsePtr &resp) {
+        EXPECT_EQ(resp->getStatusCode(), drogon::k200OK);
+    });
+    const std::string prompt = capturedPrompt();
+    EXPECT_EQ(prompt.find("Field size overrides"), std::string::npos);
+}
+
+TEST_F(AiAnalyzeImageTest, NonNumericSizeOverrideIgnored) {
+    Json::Value body = validBody();
+    body["description_size"] = "not a number";
+    invoke(buildRequest(body), [](const drogon::HttpResponsePtr &resp) {
+        EXPECT_EQ(resp->getStatusCode(), drogon::k200OK);
+    });
+    const std::string prompt = capturedPrompt();
+    EXPECT_EQ(prompt.find("Field size overrides"), std::string::npos);
 }


### PR DESCRIPTION
## Summary

Lets the client control the character length of the metadata Claude generates for a product image. The `AiAnalyzeImage` analyze endpoint now accepts three **optional** numeric fields in the request body:

- `title_size`
- `description_size`
- `meta_description_size`

Each is a max-character count. When provided (and positive), an explicit size-limit instruction is appended to the prompt for that field. When absent, zero, negative, or non-numeric, the existing default wording is used unchanged (`5-12 words` / `2-4 sentences` / `max 160 chars`).

### Example request
```json
{
  "image": "<base64>",
  "mimeType": "image/jpeg",
  "title_size": 60,
  "description_size": 300,
  "meta_description_size": 200
}
```

## Implementation

- New `SizeOverrides` struct + `readSize()` helper parse the optional fields in `analyze()`.
- `sizeOverrideBlock()` builds an appended prompt block listing only the fields that were set; returns empty when none are.
- Overrides are threaded through the worker lambda into `runClaudeAndRespond()`.

## Tests

Expanded `tests/TestAiAnalyzeImage.h`. The stub `claude` script now records its argument list so tests can assert what was sent:

- no overrides → block omitted
- single field override injected, other fields absent from block
- all three fields injected with exact `<field> max <N> chars` wording
- zero / negative values ignored
- non-numeric value ignored

All 180 tests pass locally.

Closes #101

🤖 Generated with [Claude Code](https://claude.com/claude-code)