### PR TITLE
feat: optional extra_prompt field for AiAnalyzeImage

### DIFF
--- a/src/code/controllers/AiAnalyzeImage.cpp
+++ b/src/code/controllers/AiAnalyzeImage.cpp
@@ -96,6 +96,21 @@ Return strictly valid JSON. Do not wrap in code fences.)";
         return fmt::format("\n\nField size overrides (use these exact limits, in characters): {}.", parts);
     }
 
+    // Reads the optional user-supplied prompt from the body. Non-string or empty
+    // values yield an empty string (treated as unset).
+    std::string readExtraPrompt(const Json::Value &body) {
+        const Json::Value &v = body["extra_prompt"];
+        return v.isString() ? v.asString() : std::string{};
+    }
+
+    // Builds the block for the caller-supplied prompt, appended after the size
+    // overrides. Returns an empty string when no extra prompt was provided.
+    std::string extraPromptBlock(const std::string &extraPrompt) {
+        if(extraPrompt.empty())
+            return {};
+        return fmt::format("\n\nAdditional instructions from the request: {}", extraPrompt);
+    }
+
     Json::Value errorJson(const std::string &error, const std::string &detail = {}) {
         Json::Value json;
         json["error"] = error;
@@ -226,15 +241,17 @@ Return strictly valid JSON. Do not wrap in code fences.)";
     void runClaudeAndRespond(const std::shared_ptr<std::function<void(const HttpResponsePtr &)>> &callbackPtr,
                              TempDirGuard guard,
                              const std::string &imagePath,
-                             const SizeOverrides &sizes) {
+                             const SizeOverrides &sizes,
+                             const std::string &extraPrompt) {
         const std::string &dir = guard.dir();
 
         const std::string prompt = getEnv("CLAUDE_ANALYZE_IMAGE_PROMPT", std::string(DEFAULT_PROMPT).c_str());
         const std::string fullPrompt = fmt::format(
-            "{}{}\n\nUse the Read tool to load the image at {} and then analyze it. Return ONLY the JSON object — "
+            "{}{}{}\n\nUse the Read tool to load the image at {} and then analyze it. Return ONLY the JSON object — "
             "no prose, no markdown fences, no explanation.",
             prompt,
             sizeOverrideBlock(sizes),
+            extraPromptBlock(extraPrompt),
             imagePath);
 
         const std::string cmd =
@@ -306,6 +323,7 @@ void AiAnalyzeImage::analyze(const HttpRequestPtr &req, std::function<void(const
     const SizeOverrides sizes{.title = readSize(body, "title_size"),
                               .description = readSize(body, "description_size"),
                               .metaDescription = readSize(body, "meta_description_size")};
+    const std::string extraPrompt = readExtraPrompt(body);
 
     const std::string decoded = Base64::Decode(image);
     if(decoded.empty()) {
@@ -326,7 +344,8 @@ void AiAnalyzeImage::analyze(const HttpRequestPtr &req, std::function<void(const
     // class members (in the header) so dynamic init in this TU also forces
     // HttpController<T>::registrator_ to initialize at startup.
     std::lock_guard lock(workerMutex);
-    workerThreads.emplace_back([callbackPtr, guard = std::move(temp.guard), path = temp.filePath, sizes]() mutable {
-        runClaudeAndRespond(callbackPtr, std::move(guard), path, sizes);
-    });
+    workerThreads.emplace_back(
+        [callbackPtr, guard = std::move(temp.guard), path = temp.filePath, sizes, extraPrompt]() mutable {
+            runClaudeAndRespond(callbackPtr, std::move(guard), path, sizes, extraPrompt);
+        });
 }

--- a/tests/TestAiAnalyzeImage.h
+++ b/tests/TestAiAnalyzeImage.h
@@ -117,6 +117,15 @@ protected:
         future.get();
     }
 
+    // Runs the request, asserts a 200 OK, and returns the full prompt the stub
+    // claude was invoked with — the basis for all prompt-content assertions.
+    std::string promptFor(const Json::Value &body) {
+        invoke(buildRequest(body), [](const drogon::HttpResponsePtr &resp) {
+            EXPECT_EQ(resp->getStatusCode(), drogon::k200OK);
+        });
+        return capturedPrompt();
+    }
+
     static Check expectStatusAndError(drogon::HttpStatusCode code, const std::string &expectedError) {
         return [code, expectedError](const drogon::HttpResponsePtr &resp) {
             EXPECT_EQ(resp->getStatusCode(), code);
@@ -165,10 +174,7 @@ TEST_F(AiAnalyzeImageTest, ClaudeBadJson502) {
 }
 
 TEST_F(AiAnalyzeImageTest, NoSizeOverridesOmitsBlock) {
-    invoke(buildRequest(validBody()), [](const drogon::HttpResponsePtr &resp) {
-        EXPECT_EQ(resp->getStatusCode(), drogon::k200OK);
-    });
-    const std::string prompt = capturedPrompt();
+    const std::string prompt = promptFor(validBody());
     EXPECT_FALSE(prompt.empty());
     EXPECT_EQ(prompt.find("Field size overrides"), std::string::npos);
 }
@@ -176,10 +182,7 @@ TEST_F(AiAnalyzeImageTest, NoSizeOverridesOmitsBlock) {
 TEST_F(AiAnalyzeImageTest, DescriptionSizeOverrideInjected) {
     Json::Value body = validBody();
     body["description_size"] = 300;
-    invoke(buildRequest(body), [](const drogon::HttpResponsePtr &resp) {
-        EXPECT_EQ(resp->getStatusCode(), drogon::k200OK);
-    });
-    const std::string prompt = capturedPrompt();
+    const std::string prompt = promptFor(body);
     EXPECT_NE(prompt.find("Field size overrides"), std::string::npos);
     EXPECT_NE(prompt.find("description max 300 chars"), std::string::npos);
     // Fields that were not overridden must not appear in the override block.
@@ -192,10 +195,7 @@ TEST_F(AiAnalyzeImageTest, AllSizeOverridesInjected) {
     body["title_size"] = 60;
     body["description_size"] = 300;
     body["meta_description_size"] = 200;
-    invoke(buildRequest(body), [](const drogon::HttpResponsePtr &resp) {
-        EXPECT_EQ(resp->getStatusCode(), drogon::k200OK);
-    });
-    const std::string prompt = capturedPrompt();
+    const std::string prompt = promptFor(body);
     EXPECT_NE(prompt.find("title max 60 chars"), std::string::npos);
     EXPECT_NE(prompt.find("description max 300 chars"), std::string::npos);
     EXPECT_NE(prompt.find("meta_description max 200 chars"), std::string::npos);
@@ -205,19 +205,53 @@ TEST_F(AiAnalyzeImageTest, NonPositiveSizeOverridesIgnored) {
     Json::Value body = validBody();
     body["title_size"] = 0;
     body["description_size"] = -10;
-    invoke(buildRequest(body), [](const drogon::HttpResponsePtr &resp) {
-        EXPECT_EQ(resp->getStatusCode(), drogon::k200OK);
-    });
-    const std::string prompt = capturedPrompt();
+    const std::string prompt = promptFor(body);
     EXPECT_EQ(prompt.find("Field size overrides"), std::string::npos);
 }
 
 TEST_F(AiAnalyzeImageTest, NonNumericSizeOverrideIgnored) {
     Json::Value body = validBody();
     body["description_size"] = "not a number";
-    invoke(buildRequest(body), [](const drogon::HttpResponsePtr &resp) {
-        EXPECT_EQ(resp->getStatusCode(), drogon::k200OK);
-    });
-    const std::string prompt = capturedPrompt();
+    const std::string prompt = promptFor(body);
     EXPECT_EQ(prompt.find("Field size overrides"), std::string::npos);
+}
+
+TEST_F(AiAnalyzeImageTest, NoExtraPromptOmitsBlock) {
+    const std::string prompt = promptFor(validBody());
+    EXPECT_FALSE(prompt.empty());
+    EXPECT_EQ(prompt.find("Additional instructions from the request"), std::string::npos);
+}
+
+TEST_F(AiAnalyzeImageTest, ExtraPromptInjected) {
+    Json::Value body = validBody();
+    body["extra_prompt"] = "Focus on the brand name and keep the tone playful.";
+    const std::string prompt = promptFor(body);
+    EXPECT_NE(prompt.find("Additional instructions from the request"), std::string::npos);
+    EXPECT_NE(prompt.find("Focus on the brand name and keep the tone playful."), std::string::npos);
+}
+
+TEST_F(AiAnalyzeImageTest, EmptyExtraPromptIgnored) {
+    Json::Value body = validBody();
+    body["extra_prompt"] = "";
+    const std::string prompt = promptFor(body);
+    EXPECT_EQ(prompt.find("Additional instructions from the request"), std::string::npos);
+}
+
+TEST_F(AiAnalyzeImageTest, NonStringExtraPromptIgnored) {
+    Json::Value body = validBody();
+    body["extra_prompt"] = 123;
+    const std::string prompt = promptFor(body);
+    EXPECT_EQ(prompt.find("Additional instructions from the request"), std::string::npos);
+}
+
+TEST_F(AiAnalyzeImageTest, ExtraPromptAppearsAfterSizeOverrides) {
+    Json::Value body = validBody();
+    body["title_size"] = 60;
+    body["extra_prompt"] = "Emphasize seasonal colors.";
+    const std::string prompt = promptFor(body);
+    const auto sizePos = prompt.find("Field size overrides");
+    const auto extraPos = prompt.find("Additional instructions from the request");
+    ASSERT_NE(sizePos, std::string::npos);
+    ASSERT_NE(extraPos, std::string::npos);
+    EXPECT_LT(sizePos, extraPos);
 }


### PR DESCRIPTION
## Summary

Adds an optional `extra_prompt` string field to the `AiAnalyzeImage` analyze request body. The caller (frontend) can supply additional free-form instructions that are **appended** to the existing prompt rather than replacing it.

### Behavior
- Optional `extra_prompt` (string) in the request body.
- When set, an `Additional instructions from the request: <text>` block is appended to the prompt, **after** the per-field size overrides.
- Empty string or non-string values are ignored (treated as unset), mirroring the existing `*_size` / `readSize` pattern.

### Safety
- Text flows through `shellQuote()` before `popen` → no shell injection.
- Endpoint remains JWT-gated (`JwtGoogleFilter`).

### Tests
- Block injected when set; ignored when empty or non-string.
- Ordering: extra prompt appears after the size-override block.
- Extracted a `promptFor()` test helper that removes duplicated invoke/capture boilerplate from the existing size-override tests.

All 185 tests pass locally (`ctest --preset ninja-debug`).

Closes #103

🤖 Generated with [Claude Code](https://claude.com/claude-code)