### PR TITLE
feat: inline size injection for AiAnalyzeImage

### DIFF
--- a/docs/superpowers/plans/2026-06-03-inline-size-injection.md
+++ b/docs/superpowers/plans/2026-06-03-inline-size-injection.md
@@ -1,0 +1,431 @@
+# Inline Size Injection Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Replace the appended "Field size overrides" block in `AiAnalyzeImage` with direct inline injection of size targets into the prompt's JSON-shape placeholders, with per-field min/max validation and silent fallback to default wording.
+
+**Architecture:** The single `DEFAULT_PROMPT` constant is split around its three placeholder lines into a fixed prefix and a fixed suffix. A new `buildPrompt(const SizeOverrides &)` assembles the full default prompt, choosing per field between override wording (`approximately N characters`) and default wording. `readSize` gains per-field `min`/`max` bounds; out-of-range values become `0` (unset). `sizeOverrideBlock()` and the `CLAUDE_ANALYZE_IMAGE_PROMPT` env override are deleted. `extra_prompt` handling is untouched.
+
+**Tech Stack:** C++20, Drogon, fmt, jsoncpp, Google Test. Build via CMake presets (`ninja-debug`), tests via `ctest`. Tests drive the real `analyze()` endpoint through a stub `claude` script on `PATH` that records the exact prompt.
+
+---
+
+## File Structure
+
+- `src/code/controllers/AiAnalyzeImage.cpp` — the only production file changed. The anonymous namespace gains `buildPrompt`, changes `readSize`'s signature, and loses `sizeOverrideBlock`. `runClaudeAndRespond` switches from `getEnv(...) + sizeOverrideBlock(sizes)` to `buildPrompt(sizes)`. The call site in `analyze()` passes per-field bounds to `readSize`.
+- `tests/TestAiAnalyzeImage.h` — rewrite the size-override tests to the new inline wording, keep the fallback tests (updated assertions), and add per-field bounds tests.
+
+No new files. No header changes (`SizeOverrides` shape is unchanged; everything stays in the anonymous namespace).
+
+---
+
+## Reference: target wording
+
+When a field **is** overridden (in range), its placeholder line becomes exactly:
+
+```
+  "title": "<product title, approximately N characters>",
+  "description": "<engaging product description, approximately N characters>",
+  "meta_description": "<SEO meta description, approximately N characters>",
+```
+
+When a field is **not** overridden, it keeps its original default wording:
+
+```
+  "title": "<short product title, 5-12 words>",
+  "description": "<2-4 sentence engaging product description>",
+  "meta_description": "<SEO meta description, max 160 chars>",
+```
+
+Per-field bounds (inclusive):
+
+| Field            | body key                 | min | max  |
+|------------------|--------------------------|-----|------|
+| title            | `title_size`             | 10  | 60   |
+| description      | `description_size`       | 50  | 1000 |
+| meta_description | `meta_description_size`  | 50  | 160  |
+
+---
+
+## Task 1: Add per-field bounds to `readSize`
+
+**Files:**
+- Test: `tests/TestAiAnalyzeImage.h` (rewrite existing fallback tests + add bounds tests)
+- Modify: `src/code/controllers/AiAnalyzeImage.cpp:72-78` (`readSize`) and call site `:323-325`
+
+This task changes `readSize`'s signature and call site but does NOT yet change the prompt wording. To keep the build green between tasks, we change `sizeOverrideBlock` only minimally is NOT needed — instead, this task is done together with Task 2's wording because the tests assert wording. **Therefore Task 1 only writes the bounds tests and the `readSize` change; the wording switch in `buildPrompt` lands in Task 2. The intermediate state will have failing wording tests until Task 2 — that is expected and noted per step.**
+
+> NOTE: Because the existing tests assert the OLD `"Field size overrides"` wording, this plan rewrites the whole `.cpp` and the whole test block as one coherent change across Tasks 1–3, each committed once green. Do the steps in order; do not run the full suite expecting green until the end of Task 3.
+
+- [ ] **Step 1: Change `readSize` to enforce per-field bounds**
+
+Replace the existing `readSize` (lines 70-78) with:
+
+```cpp
+    // Reads an optional character-count override from the body and validates it
+    // against the field's [min, max] range. Non-integral, below-min, or above-max
+    // values are treated as unset (return 0 → default prompt wording for the field).
+    int readSize(const Json::Value &body, const char *key, int min, int max) {
+        const Json::Value &v = body[key];
+        if(!v.isIntegral())
+            return 0;
+        const int n = v.asInt();
+        return (n >= min && n <= max) ? n : 0;
+    }
+```
+
+- [ ] **Step 2: Update the call site in `analyze()` to pass bounds**
+
+Replace lines 323-325:
+
+```cpp
+    const SizeOverrides sizes{.title = readSize(body, "title_size", 10, 60),
+                              .description = readSize(body, "description_size", 50, 1000),
+                              .metaDescription = readSize(body, "meta_description_size", 50, 160)};
+```
+
+(Proceed directly to Task 2 — do not build yet; `sizeOverrideBlock` still references the old wording the tests will be rewritten away from.)
+
+---
+
+## Task 2: Split `DEFAULT_PROMPT` and add `buildPrompt`; delete `sizeOverrideBlock` and the env override
+
+**Files:**
+- Modify: `src/code/controllers/AiAnalyzeImage.cpp` — `DEFAULT_PROMPT` (lines 33-56), `sizeOverrideBlock` (lines 80-97, delete), `runClaudeAndRespond` (lines 248-255)
+
+- [ ] **Step 1: Replace `DEFAULT_PROMPT` with prefix/suffix constants**
+
+Replace the `DEFAULT_PROMPT` definition (lines 33-56) with the split prefix and suffix:
+
+```cpp
+    // The default prompt is split around its three placeholder lines (title,
+    // description, meta_description) so buildPrompt() can inject per-field size
+    // targets inline. PREFIX ends just before the JSON shape's opening brace
+    // body; SUFFIX begins right after the meta_description line.
+    constexpr std::string_view PROMPT_PREFIX =
+        R"(You are an assistant that generates social-media-ready metadata for product images.
+
+Look at the attached image and return ONLY a JSON object (no prose, no markdown) with this exact shape:
+{
+)";
+
+    constexpr std::string_view PROMPT_SUFFIX =
+        R"(  "tags": [
+    { "title": "<TagName>", "social_media": ["Instagram","Pinterest","Twitter","Facebook","TikTok","YouTube"] }
+  ]
+}
+
+Tag rules per platform:
+- Instagram: up to 30 tags total may include Instagram in social_media
+- Pinterest: 5-7 tags may include Pinterest
+- Twitter: 3-5 tags may include Twitter
+- Facebook: 5-10 tags may include Facebook
+- TikTok: 3-8 tags may include TikTok
+- YouTube: 5-15 tags may include YouTube
+
+A single tag can be reused for multiple platforms (list every platform it suits in its social_media array).
+Tag titles must be a single CamelCase or PascalCase word without spaces or punctuation.
+Return strictly valid JSON. Do not wrap in code fences.)";
+```
+
+- [ ] **Step 2: Add `buildPrompt` after the `SizeOverrides` struct**
+
+Add this function immediately after the `SizeOverrides` struct (after line 68, before `readSize`). It emits the three placeholder lines between prefix and suffix, choosing override vs default wording per field:
+
+```cpp
+    // Assembles the default prompt with per-field size targets injected inline
+    // into the three JSON-shape placeholders. A field with size > 0 uses the
+    // "approximately N characters" target wording (enabling shrink AND expand);
+    // an unset field (0) keeps its natural default wording.
+    std::string buildPrompt(const SizeOverrides &sizes) {
+        const std::string title = sizes.title > 0
+            ? fmt::format(R"(  "title": "<product title, approximately {} characters>",)", sizes.title)
+            : R"(  "title": "<short product title, 5-12 words>",)";
+        const std::string description = sizes.description > 0
+            ? fmt::format(R"(  "description": "<engaging product description, approximately {} characters>",)",
+                          sizes.description)
+            : R"(  "description": "<2-4 sentence engaging product description>",)";
+        const std::string metaDescription = sizes.metaDescription > 0
+            ? fmt::format(R"(  "meta_description": "<SEO meta description, approximately {} characters>",)",
+                          sizes.metaDescription)
+            : R"(  "meta_description": "<SEO meta description, max 160 chars>",)";
+
+        return fmt::format("{}{}\n{}\n{}\n{}", PROMPT_PREFIX, title, description, metaDescription, PROMPT_SUFFIX);
+    }
+```
+
+- [ ] **Step 3: Delete `sizeOverrideBlock`**
+
+Delete the entire `sizeOverrideBlock` function (originally lines 80-97, including its leading comment lines 80-81).
+
+- [ ] **Step 4: Rewrite `runClaudeAndRespond`'s prompt assembly**
+
+Replace lines 248-255 (the `getEnv(...)` line through the `fmt::format(...)` that built `fullPrompt`) with:
+
+```cpp
+        const std::string fullPrompt = fmt::format(
+            "{}{}\n\nUse the Read tool to load the image at {} and then analyze it. Return ONLY the JSON object — "
+            "no prose, no markdown fences, no explanation.",
+            buildPrompt(sizes),
+            extraPromptBlock(extraPrompt),
+            imagePath);
+```
+
+(Note: the old format string had three `{}` for `prompt`, `sizeOverrideBlock(sizes)`, `extraPromptBlock(extraPrompt)`. The new one has two: `buildPrompt(sizes)` and `extraPromptBlock(extraPrompt)`.)
+
+- [ ] **Step 5: Verify the `<string_view>` include and `getEnv` usage**
+
+`getEnv` is still used by `writeTempImage` (`FOXY_AI_WORKDIR`), so the `utils/config.h` include stays. `std::string_view` is still used (`PROMPT_PREFIX`/`PROMPT_SUFFIX`, `shellQuote`, `extensionFor`), so its include stays. No include changes needed. Confirm by grep:
+
+Run: `grep -n "getEnv\|string_view" src/code/controllers/AiAnalyzeImage.cpp`
+Expected: `getEnv` appears in `writeTempImage`; `string_view` appears in includes and several functions. No reference to `CLAUDE_ANALYZE_IMAGE_PROMPT` remains.
+
+Run: `grep -n "CLAUDE_ANALYZE_IMAGE_PROMPT\|sizeOverrideBlock\|DEFAULT_PROMPT" src/code/controllers/AiAnalyzeImage.cpp`
+Expected: no output (all three are gone).
+
+---
+
+## Task 3: Rewrite and extend the tests, then build and run green
+
+**Files:**
+- Modify: `tests/TestAiAnalyzeImage.h` — rewrite the four size tests, update the two fallback tests, add bounds tests.
+
+- [ ] **Step 1: Rewrite `NoSizeOverridesOmitsBlock`**
+
+Replace the test at lines 176-180 with (rename to reflect new behavior):
+
+```cpp
+TEST_F(AiAnalyzeImageTest, NoSizeOverridesKeepsDefaultWording) {
+    const std::string prompt = promptFor(validBody());
+    EXPECT_FALSE(prompt.empty());
+    EXPECT_EQ(prompt.find("approximately"), std::string::npos);
+    EXPECT_NE(prompt.find("short product title, 5-12 words"), std::string::npos);
+    EXPECT_NE(prompt.find("2-4 sentence engaging product description"), std::string::npos);
+    EXPECT_NE(prompt.find("SEO meta description, max 160 chars"), std::string::npos);
+}
+```
+
+- [ ] **Step 2: Rewrite `DescriptionSizeOverrideInjected`**
+
+Replace the test at lines 182-191 with:
+
+```cpp
+TEST_F(AiAnalyzeImageTest, DescriptionSizeOverrideInjected) {
+    Json::Value body = validBody();
+    body["description_size"] = 300;
+    const std::string prompt = promptFor(body);
+    EXPECT_NE(prompt.find("engaging product description, approximately 300 characters"), std::string::npos);
+    // Other fields keep their default wording.
+    EXPECT_NE(prompt.find("short product title, 5-12 words"), std::string::npos);
+    EXPECT_NE(prompt.find("SEO meta description, max 160 chars"), std::string::npos);
+}
+```
+
+- [ ] **Step 3: Rewrite `AllSizeOverridesInjected`**
+
+Replace the test at lines 193-202 with (note `description_size` 300 stays in [50,1000]; `meta_description_size` lowered to 150 to stay in [50,160]):
+
+```cpp
+TEST_F(AiAnalyzeImageTest, AllSizeOverridesInjected) {
+    Json::Value body = validBody();
+    body["title_size"] = 60;
+    body["description_size"] = 300;
+    body["meta_description_size"] = 150;
+    const std::string prompt = promptFor(body);
+    EXPECT_NE(prompt.find("product title, approximately 60 characters"), std::string::npos);
+    EXPECT_NE(prompt.find("engaging product description, approximately 300 characters"), std::string::npos);
+    EXPECT_NE(prompt.find("SEO meta description, approximately 150 characters"), std::string::npos);
+    // No default wording remains for the overridden fields.
+    EXPECT_EQ(prompt.find("5-12 words"), std::string::npos);
+    EXPECT_EQ(prompt.find("2-4 sentence"), std::string::npos);
+    EXPECT_EQ(prompt.find("max 160 chars"), std::string::npos);
+}
+```
+
+- [ ] **Step 4: Update `NonPositiveSizeOverridesIgnored`**
+
+Replace the test at lines 204-210 with:
+
+```cpp
+TEST_F(AiAnalyzeImageTest, NonPositiveSizeOverridesIgnored) {
+    Json::Value body = validBody();
+    body["title_size"] = 0;
+    body["description_size"] = -10;
+    const std::string prompt = promptFor(body);
+    EXPECT_EQ(prompt.find("approximately"), std::string::npos);
+    EXPECT_NE(prompt.find("short product title, 5-12 words"), std::string::npos);
+    EXPECT_NE(prompt.find("2-4 sentence engaging product description"), std::string::npos);
+}
+```
+
+- [ ] **Step 5: Update `NonNumericSizeOverrideIgnored`**
+
+Replace the test at lines 212-217 with:
+
+```cpp
+TEST_F(AiAnalyzeImageTest, NonNumericSizeOverrideIgnored) {
+    Json::Value body = validBody();
+    body["description_size"] = "not a number";
+    const std::string prompt = promptFor(body);
+    EXPECT_EQ(prompt.find("approximately"), std::string::npos);
+    EXPECT_NE(prompt.find("2-4 sentence engaging product description"), std::string::npos);
+}
+```
+
+- [ ] **Step 6: Rework `ExtraPromptAppearsAfterSizeOverrides`**
+
+Replace the test at lines 247-257 with (now anchors on the inline override text instead of the deleted block):
+
+```cpp
+TEST_F(AiAnalyzeImageTest, ExtraPromptAppearsAfterSizeOverrides) {
+    Json::Value body = validBody();
+    body["title_size"] = 60;
+    body["extra_prompt"] = "Emphasize seasonal colors.";
+    const std::string prompt = promptFor(body);
+    const auto sizePos = prompt.find("product title, approximately 60 characters");
+    const auto extraPos = prompt.find("Additional instructions from the request");
+    ASSERT_NE(sizePos, std::string::npos);
+    ASSERT_NE(extraPos, std::string::npos);
+    EXPECT_LT(sizePos, extraPos);
+}
+```
+
+- [ ] **Step 7: Add per-field above-max bounds tests**
+
+Add after the `AllSizeOverridesInjected` test:
+
+```cpp
+TEST_F(AiAnalyzeImageTest, TitleSizeAboveMaxFallsBack) {
+    Json::Value body = validBody();
+    body["title_size"] = 200;  // > 60
+    const std::string prompt = promptFor(body);
+    EXPECT_EQ(prompt.find("title, approximately"), std::string::npos);
+    EXPECT_NE(prompt.find("short product title, 5-12 words"), std::string::npos);
+}
+
+TEST_F(AiAnalyzeImageTest, DescriptionSizeAboveMaxFallsBack) {
+    Json::Value body = validBody();
+    body["description_size"] = 5000;  // > 1000
+    const std::string prompt = promptFor(body);
+    EXPECT_EQ(prompt.find("description, approximately"), std::string::npos);
+    EXPECT_NE(prompt.find("2-4 sentence engaging product description"), std::string::npos);
+}
+
+TEST_F(AiAnalyzeImageTest, MetaDescriptionSizeAboveMaxFallsBack) {
+    Json::Value body = validBody();
+    body["meta_description_size"] = 500;  // > 160
+    const std::string prompt = promptFor(body);
+    EXPECT_EQ(prompt.find("meta description, approximately"), std::string::npos);
+    EXPECT_NE(prompt.find("SEO meta description, max 160 chars"), std::string::npos);
+}
+```
+
+- [ ] **Step 8: Add per-field below-min bounds tests**
+
+Add after the above-max tests:
+
+```cpp
+TEST_F(AiAnalyzeImageTest, TitleSizeBelowMinFallsBack) {
+    Json::Value body = validBody();
+    body["title_size"] = 3;  // < 10
+    const std::string prompt = promptFor(body);
+    EXPECT_EQ(prompt.find("title, approximately"), std::string::npos);
+    EXPECT_NE(prompt.find("short product title, 5-12 words"), std::string::npos);
+}
+
+TEST_F(AiAnalyzeImageTest, DescriptionSizeBelowMinFallsBack) {
+    Json::Value body = validBody();
+    body["description_size"] = 10;  // < 50
+    const std::string prompt = promptFor(body);
+    EXPECT_EQ(prompt.find("description, approximately"), std::string::npos);
+    EXPECT_NE(prompt.find("2-4 sentence engaging product description"), std::string::npos);
+}
+
+TEST_F(AiAnalyzeImageTest, MetaDescriptionSizeBelowMinFallsBack) {
+    Json::Value body = validBody();
+    body["meta_description_size"] = 10;  // < 50
+    const std::string prompt = promptFor(body);
+    EXPECT_EQ(prompt.find("meta description, approximately"), std::string::npos);
+    EXPECT_NE(prompt.find("SEO meta description, max 160 chars"), std::string::npos);
+}
+```
+
+- [ ] **Step 9: Add boundary tests (exact min/max inject; just-outside fall back)**
+
+Add after the below-min tests:
+
+```cpp
+TEST_F(AiAnalyzeImageTest, TitleSizeBoundariesInject) {
+    Json::Value max = validBody();
+    max["title_size"] = 60;  // == max
+    EXPECT_NE(promptFor(max).find("product title, approximately 60 characters"), std::string::npos);
+
+    Json::Value min = validBody();
+    min["title_size"] = 10;  // == min
+    EXPECT_NE(promptFor(min).find("product title, approximately 10 characters"), std::string::npos);
+}
+
+TEST_F(AiAnalyzeImageTest, TitleSizeJustOutsideBoundariesFallBack) {
+    Json::Value over = validBody();
+    over["title_size"] = 61;  // max + 1
+    EXPECT_EQ(promptFor(over).find("title, approximately"), std::string::npos);
+
+    Json::Value under = validBody();
+    under["title_size"] = 9;  // min - 1
+    EXPECT_EQ(promptFor(under).find("title, approximately"), std::string::npos);
+}
+```
+
+- [ ] **Step 10: Add a mixed in-range / out-of-range / unset test**
+
+Add after the boundary tests:
+
+```cpp
+TEST_F(AiAnalyzeImageTest, MixedSizeOverridesInjectOnlyInRange) {
+    Json::Value body = validBody();
+    body["title_size"] = 50;            // in range → inject
+    body["description_size"] = 5000;    // out of range → fall back
+    // meta_description_size unset → fall back
+    const std::string prompt = promptFor(body);
+    EXPECT_NE(prompt.find("product title, approximately 50 characters"), std::string::npos);
+    EXPECT_NE(prompt.find("2-4 sentence engaging product description"), std::string::npos);
+    EXPECT_NE(prompt.find("SEO meta description, max 160 chars"), std::string::npos);
+    EXPECT_EQ(prompt.find("description, approximately"), std::string::npos);
+    EXPECT_EQ(prompt.find("meta description, approximately"), std::string::npos);
+}
+```
+
+- [ ] **Step 11: Build**
+
+Run: `cmake --preset ninja-debug && cmake --build --preset ninja-debug 2>&1 | tail -20`
+Expected: build succeeds, no warnings-as-errors failures.
+
+- [ ] **Step 12: Run the AiAnalyzeImage tests**
+
+Run: `ctest --preset ninja-debug -R AiAnalyzeImage --output-on-failure`
+Expected: all `AiAnalyzeImageTest.*` tests PASS (the existing four endpoint tests plus all rewritten/new prompt tests).
+
+- [ ] **Step 13: Run the full test suite to confirm no regressions**
+
+Run: `ctest --preset ninja-debug --output-on-failure`
+Expected: all tests PASS.
+
+- [ ] **Step 14: Format**
+
+Run: `cmake --build build/debug --target clang-format`
+Expected: no diff, or only formatting of the touched files.
+
+- [ ] **Step 15: Commit**
+
+```bash
+git add src/code/controllers/AiAnalyzeImage.cpp tests/TestAiAnalyzeImage.h docs/superpowers/plans/2026-06-03-inline-size-injection.md
+git commit -m "feat: inline size injection for AiAnalyzeImage (#104)"
+```
+
+---
+
+## Self-Review notes
+
+- **Spec coverage:** Decision 1 (drop env override) → Task 2 Step 4/5. Decision 2 (per-field validation) → Task 1. Decision 3/4 (chars unit, "approximately N characters") → Task 2 Step 2. Decision 5 (`extra_prompt` unchanged) → untouched; verified by retained extra-prompt tests. Decision 6 (delete `sizeOverrideBlock`) → Task 2 Step 3. Per-field ranges table → Task 1 Step 2 + Task 3 bounds tests. Testing section's Rewrite/Keep/Add lists → Task 3 Steps 1-10.
+- **Type consistency:** `readSize(body, key, min, max)` signature defined in Task 1 Step 1, used in Task 1 Step 2. `buildPrompt(const SizeOverrides &)` defined in Task 2 Step 2, used in Task 2 Step 4. `SizeOverrides` shape unchanged.
+- **Wording consistency:** every test's substring (`product title, approximately N characters`, `engaging product description, approximately N characters`, `SEO meta description, approximately N characters`) matches exactly what `buildPrompt` emits in Task 2 Step 2. The `title, approximately` / `description, approximately` / `meta description, approximately` negative-match substrings are unique prefixes of those override strings, so they correctly detect injection per field.

--- a/docs/superpowers/specs/2026-06-03-inline-size-injection-design.md
+++ b/docs/superpowers/specs/2026-06-03-inline-size-injection-design.md
@@ -57,7 +57,12 @@ wording for that field.
 |------------------|--------------------------|-------|-----|------|------------------------------------------------|
 | title            | `title_size`             | chars | 10  | 100  | `<short product title, 5-12 words>`            |
 | description      | `description_size`       | chars | 50  | 1000 | `<2-4 sentence engaging product description>`  |
-| meta_description | `meta_description_size`  | chars | 50  | 300  | `<SEO meta description, max 160 chars>`         |
+| meta_description | `meta_description_size`  | chars | 50  | 160  | `<SEO meta description, max 160 chars>`         |
+
+The `meta_description` max is capped at **160** to match Google's SERP snippet
+truncation point (~155–160 chars desktop). Google has no official required
+length and may rewrite snippets, but ~160 is the established SEO-safe target, so
+allowing longer overrides would just get truncated in results.
 
 When overridden and in range, the placeholder becomes:
 
@@ -101,7 +106,7 @@ Call sites pass the bounds:
 const SizeOverrides sizes{
     .title           = readSize(body, "title_size", 10, 100),
     .description     = readSize(body, "description_size", 50, 1000),
-    .metaDescription = readSize(body, "meta_description_size", 50, 300)};
+    .metaDescription = readSize(body, "meta_description_size", 50, 160)};
 ```
 
 ### 3. Remove `sizeOverrideBlock()`

--- a/docs/superpowers/specs/2026-06-03-inline-size-injection-design.md
+++ b/docs/superpowers/specs/2026-06-03-inline-size-injection-design.md
@@ -149,26 +149,50 @@ is no downstream impact.
 
 ## Testing
 
-The valuable, deterministic coverage is the prompt-building / validation logic,
-which is pure (no network, no `popen`):
+`tests/TestAiAnalyzeImage.h` already exists and tests prompt content **without**
+touching internal functions: a stub `claude` script is placed on `PATH`, records
+the exact prompt it was invoked with, and the tests assert against that captured
+string (`promptFor(body)` → `capturedPrompt()`). This means the anonymous
+namespace is **not** an obstacle — there is no need to move `buildPrompt` /
+`readSize` out of it or to expose any internal symbol. We drive the real
+`analyze()` endpoint and inspect the real prompt.
 
-- `readSize` bounds: for each field, assert below-min, in-range, above-max,
-  non-integral, and missing → correct `0`-or-value result.
-- `buildPrompt`: for each field, assert that an in-range override produces
-  `approximately N characters` and that an unset field keeps its default wording.
-  Spot-check a mixed case (one field overridden, two default).
+The existing tests encode the **old** appended-block behavior and must be updated
+to the new inline wording. Concretely:
 
-The `popen`/CLI execution path is left as-is (unchanged behavior, hard to unit
-test without invoking the CLI).
+**Rewrite (asserted old `"Field size overrides"` block — now gone):**
+- `NoSizeOverridesOmitsBlock` → assert the prompt keeps the *default* placeholder
+  wording (`5-12 words`, `2-4 sentence`, `max 160 chars`) and contains no
+  `approximately N characters`.
+- `DescriptionSizeOverrideInjected` → with `description_size` in range, assert the
+  prompt contains `engaging product description, approximately N characters` and
+  that title/meta keep their default wording.
+- `AllSizeOverridesInjected` → assert all three placeholders switch to
+  `approximately N characters` with the right N (use in-range values:
+  title ≤ 60, description 50–1000, meta ≤ 160).
+- `ExtraPromptAppearsAfterSizeOverrides` → rework: it currently locates the old
+  block. Assert instead that the inline-overridden placeholder text appears before
+  the appended `Additional instructions from the request:` block.
 
-**Testability note:** `buildPrompt` and `readSize` currently live in an anonymous
-namespace (`namespace {` at the top of the TU), so they are not linkable from a
-test translation unit. To unit-test them, they must be exposed — either moved out
-of the anonymous namespace into `api::v1` (and declared in a header), or the pure
-logic extracted to a small testable helper. The implementation plan must pick one;
-the recommendation is to move both into `api::v1` with a header declaration,
-matching how other testable helpers in the project are organized. Confirm this
-against an existing controller's test setup before finalizing.
+**Keep (still valid — fallback to unset):**
+- `NonPositiveSizeOverridesIgnored`, `NonNumericSizeOverrideIgnored` → still fall
+  back to default wording; update assertions to check default wording is present
+  and `approximately` is absent.
+- All `extra_prompt` tests except the reworked ordering one.
+
+**Add (new per-field bounds — the core of this change):**
+- For each field, an **above-max** override (e.g. `title_size = 200`,
+  `description_size = 5000`, `meta_description_size = 500`) → falls back to that
+  field's default wording, no `approximately`.
+- For each field, a **below-min** override (e.g. `title_size = 3`,
+  `description_size = 10`, `meta_description_size = 10`) → same fallback.
+- A **boundary** check at each min and max (e.g. `title_size = 60` and `= 10`
+  inject; `= 61` and `= 9` fall back).
+- A **mixed** case: one field in range, one out of range, one unset → only the
+  in-range field shows `approximately`.
+
+The `popen`/CLI execution path is left as-is (the stub script already covers the
+success, failure, and bad-JSON branches).
 
 ## Out of scope
 

--- a/docs/superpowers/specs/2026-06-03-inline-size-injection-design.md
+++ b/docs/superpowers/specs/2026-06-03-inline-size-injection-design.md
@@ -55,9 +55,14 @@ wording for that field.
 
 | Field            | `*_size` body key        | Unit  | min | max  | Default wording when not overridden            |
 |------------------|--------------------------|-------|-----|------|------------------------------------------------|
-| title            | `title_size`             | chars | 10  | 100  | `<short product title, 5-12 words>`            |
+| title            | `title_size`             | chars | 10  | 60   | `<short product title, 5-12 words>`            |
 | description      | `description_size`       | chars | 50  | 1000 | `<2-4 sentence engaging product description>`  |
 | meta_description | `meta_description_size`  | chars | 50  | 160  | `<SEO meta description, max 160 chars>`         |
+
+The `title` max is capped at **60** to match Google's SERP title truncation
+(~50–60 chars / ~600px desktop), since the title doubles as the SEO page title.
+The `description` field is product *content* (not a meta tag), so Google imposes
+no length rule — its 50–1000 range is just sane bounds.
 
 The `meta_description` max is capped at **160** to match Google's SERP snippet
 truncation point (~155–160 chars desktop). Google has no official required
@@ -104,7 +109,7 @@ Call sites pass the bounds:
 
 ```cpp
 const SizeOverrides sizes{
-    .title           = readSize(body, "title_size", 10, 100),
+    .title           = readSize(body, "title_size", 10, 60),
     .description     = readSize(body, "description_size", 50, 1000),
     .metaDescription = readSize(body, "meta_description_size", 50, 160)};
 ```

--- a/docs/superpowers/specs/2026-06-03-inline-size-injection-design.md
+++ b/docs/superpowers/specs/2026-06-03-inline-size-injection-design.md
@@ -1,0 +1,167 @@
+# Inline size injection for AiAnalyzeImage
+
+**Date:** 2026-06-03
+**File touched:** `src/code/controllers/AiAnalyzeImage.cpp`
+
+## Problem
+
+`AiAnalyzeImage` lets callers pass per-field character-size overrides
+(`title_size`, `description_size`, `meta_description_size`). Today these are
+expressed as a **separate block appended** to the end of the prompt:
+
+```
+Field size overrides (use these exact limits, in characters): title max 60; description max 200.
+```
+
+This conflicts with the inline placeholder wording that still lives in the JSON
+shape (`<short product title, 5-12 words>`, `<SEO meta description, max 160
+chars>`). Two instructions fight:
+
+- The inline placeholder says "be short / max 160".
+- The appended block says "use these exact limits".
+
+Consequences:
+- **Shrinking** works (a `max` below default genuinely constrains).
+- **Expanding** is unreliable — `max N` is read as a ceiling, not a target, and
+  the "short / 2-4 sentence" inline wording still pulls the model down.
+
+## Goal
+
+Replace the append-a-block approach with **direct inline injection** into the
+prompt's JSON-shape placeholders, so each field carries a single,
+non-conflicting instruction. This enables both shrinking and expanding.
+Validate sizes per field; out-of-range values silently fall back to the default
+wording for that field.
+
+## Decisions (from brainstorming)
+
+1. **Drop the `CLAUDE_ANALYZE_IMAGE_PROMPT` env override entirely.** Always use
+   the templated default prompt. Nothing else in the repo references this var.
+2. **Per-field min/max validation.** Each field has its own sane character range.
+   Out-of-range (or non-positive / non-integral) → treat as unset → default
+   wording for that field. No error is returned; it just falls back.
+3. **Override unit is always characters.** Matches the `*_size` field names.
+   When a field is overridden, its placeholder switches to
+   `approximately N characters`. When a field is **not** overridden, it keeps its
+   natural default wording (title in words, description in sentences, meta in
+   chars).
+4. **Wording when set:** `approximately N characters` (a target, encouraging the
+   model to fill toward N — enabling expansion).
+5. **`extra_prompt` is unchanged** — it stays appended via `extraPromptBlock()`.
+   Only the size handling moves from append to inline injection.
+6. **Delete `sizeOverrideBlock()`** outright.
+
+## Per-field ranges and fallback wording
+
+| Field            | `*_size` body key        | Unit  | min | max  | Default wording when not overridden            |
+|------------------|--------------------------|-------|-----|------|------------------------------------------------|
+| title            | `title_size`             | chars | 10  | 100  | `<short product title, 5-12 words>`            |
+| description      | `description_size`       | chars | 50  | 1000 | `<2-4 sentence engaging product description>`  |
+| meta_description | `meta_description_size`  | chars | 50  | 300  | `<SEO meta description, max 160 chars>`         |
+
+When overridden and in range, the placeholder becomes:
+
+```
+"title":            "<product title, approximately N characters>"
+"description":      "<engaging product description, approximately N characters>"
+"meta_description": "<SEO meta description, approximately N characters>"
+```
+
+## Implementation
+
+All changes are in `src/code/controllers/AiAnalyzeImage.cpp`.
+
+### 1. Make the prompt a template
+
+`DEFAULT_PROMPT` currently is a `constexpr std::string_view`. The fixed prefix
+("You are an assistant...") and the fixed suffix (tag rules, etc.) stay constant.
+The three placeholder lines become substitution points filled by a builder
+function.
+
+Approach: keep the constant text split around the three placeholders, and have a
+function `buildPrompt(const SizeOverrides &sizes)` assemble the full default
+prompt, choosing per field between the override wording and the default wording.
+
+### 2. Per-field validation
+
+Replace the single `readSize(body, key)` (which only rejects non-positive) with a
+helper that also enforces per-field bounds, e.g.:
+
+```cpp
+int readSize(const Json::Value &body, const char *key, int min, int max);
+```
+
+Returns `0` (unset) when the value is non-integral, `< min`, or `> max`. The
+`SizeOverrides` struct is unchanged in shape; `0` continues to mean "unset →
+default wording".
+
+Call sites pass the bounds:
+
+```cpp
+const SizeOverrides sizes{
+    .title           = readSize(body, "title_size", 10, 100),
+    .description     = readSize(body, "description_size", 50, 1000),
+    .metaDescription = readSize(body, "meta_description_size", 50, 300)};
+```
+
+### 3. Remove `sizeOverrideBlock()`
+
+Delete the function and its call in `runClaudeAndRespond`. The size info is now
+carried inline by `buildPrompt(sizes)`.
+
+### 4. Remove the env override
+
+Delete the `getEnv("CLAUDE_ANALYZE_IMAGE_PROMPT", ...)` line in
+`runClaudeAndRespond`; build the prompt via `buildPrompt(sizes)` instead.
+
+### 5. `extra_prompt` unchanged
+
+`readExtraPrompt` / `extraPromptBlock` stay. `extraPromptBlock(extraPrompt)`
+remains appended after the (now inline-templated) default prompt.
+
+## Resulting `fullPrompt` structure
+
+```
+<templated default prompt — sizes injected inline into the 3 placeholders>
+<extraPromptBlock — appended, unchanged>
+
+Use the Read tool to load the image at <path> and then analyze it. Return ONLY
+the JSON object — no prose, no markdown fences, no explanation.
+```
+
+## Data flow (shape unchanged)
+
+`getJsonObject` → read the three `*_size` keys with per-field bounds → validate →
+`SizeOverrides` → captured into the worker thread → `runClaudeAndRespond` builds
+the templated prompt via `buildPrompt(sizes)`. The Claude response is still parsed
+by JSON **keys** (`title`, `description`, ...), not by placeholder text, so there
+is no downstream impact.
+
+## Testing
+
+The valuable, deterministic coverage is the prompt-building / validation logic,
+which is pure (no network, no `popen`):
+
+- `readSize` bounds: for each field, assert below-min, in-range, above-max,
+  non-integral, and missing → correct `0`-or-value result.
+- `buildPrompt`: for each field, assert that an in-range override produces
+  `approximately N characters` and that an unset field keeps its default wording.
+  Spot-check a mixed case (one field overridden, two default).
+
+The `popen`/CLI execution path is left as-is (unchanged behavior, hard to unit
+test without invoking the CLI).
+
+**Testability note:** `buildPrompt` and `readSize` currently live in an anonymous
+namespace (`namespace {` at the top of the TU), so they are not linkable from a
+test translation unit. To unit-test them, they must be exposed — either moved out
+of the anonymous namespace into `api::v1` (and declared in a header), or the pure
+logic extracted to a small testable helper. The implementation plan must pick one;
+the recommendation is to move both into `api::v1` with a header declaration,
+matching how other testable helpers in the project are organized. Confirm this
+against an existing controller's test setup before finalizing.
+
+## Out of scope
+
+- Changing the `extra_prompt` mechanism.
+- Adding new overridable fields (e.g. tag counts).
+- Rewriting the default (non-overridden) wording units.

--- a/src/code/controllers/AiAnalyzeImage.cpp
+++ b/src/code/controllers/AiAnalyzeImage.cpp
@@ -30,15 +30,19 @@ using namespace api::v1;
 using namespace drogon;
 
 namespace {
-    constexpr std::string_view DEFAULT_PROMPT =
+    // The default prompt is split around its three placeholder lines (title,
+    // description, meta_description) so buildPrompt() can inject per-field size
+    // targets inline. PREFIX ends just after the JSON shape's opening brace;
+    // SUFFIX begins right after the meta_description line.
+    constexpr std::string_view PROMPT_PREFIX =
         R"(You are an assistant that generates social-media-ready metadata for product images.
 
 Look at the attached image and return ONLY a JSON object (no prose, no markdown) with this exact shape:
 {
-  "title": "<short product title, 5-12 words>",
-  "description": "<2-4 sentence engaging product description>",
-  "meta_description": "<SEO meta description, max 160 chars>",
-  "tags": [
+)";
+
+    constexpr std::string_view PROMPT_SUFFIX =
+        R"(  "tags": [
     { "title": "<TagName>", "social_media": ["Instagram","Pinterest","Twitter","Facebook","TikTok","YouTube"] }
   ]
 }
@@ -61,39 +65,39 @@ Return strictly valid JSON. Do not wrap in code fences.)";
         int title = 0;
         int description = 0;
         int metaDescription = 0;
-
-        [[nodiscard]] bool any() const noexcept {
-            return title > 0 || description > 0 || metaDescription > 0;
-        }
     };
 
-    // Reads an optional positive integer override from the body. Non-numeric or
-    // non-positive values are treated as unset (return 0).
-    int readSize(const Json::Value &body, const char *key) {
+    // Assembles the default prompt with per-field size targets injected inline
+    // into the three JSON-shape placeholders. A field with size > 0 uses the
+    // "approximately N characters" target wording (enabling shrink AND expand);
+    // an unset field (0) keeps its natural default wording.
+    std::string buildPrompt(const SizeOverrides &sizes) {
+        const std::string title =
+            sizes.title > 0 ? fmt::format(R"(  "title": "<product title, approximately {} characters>",)", sizes.title)
+                            : std::string(R"(  "title": "<short product title, 5-12 words>",)");
+        const std::string description =
+            sizes.description > 0
+                ? fmt::format(R"(  "description": "<engaging product description, approximately {} characters>",)",
+                              sizes.description)
+                : std::string(R"(  "description": "<2-4 sentence engaging product description>",)");
+        const std::string metaDescription =
+            sizes.metaDescription > 0
+                ? fmt::format(R"(  "meta_description": "<SEO meta description, approximately {} characters>",)",
+                              sizes.metaDescription)
+                : std::string(R"(  "meta_description": "<SEO meta description, max 160 chars>",)");
+
+        return fmt::format("{}{}\n{}\n{}\n{}", PROMPT_PREFIX, title, description, metaDescription, PROMPT_SUFFIX);
+    }
+
+    // Reads an optional character-count override from the body and validates it
+    // against the field's [min, max] range. Non-integral, below-min, or above-max
+    // values are treated as unset (return 0 → default prompt wording for the field).
+    int readSize(const Json::Value &body, const char *key, int min, int max) {
         const Json::Value &v = body[key];
         if(!v.isIntegral())
             return 0;
         const int n = v.asInt();
-        return n > 0 ? n : 0;
-    }
-
-    // Builds the override instruction appended to the prompt. Only lists fields
-    // that were actually set. Returns an empty string when nothing is overridden.
-    std::string sizeOverrideBlock(const SizeOverrides &sizes) {
-        if(!sizes.any())
-            return {};
-        std::string parts;
-        const auto add = [&parts](std::string_view name, int n) {
-            if(n <= 0)
-                return;
-            if(!parts.empty())
-                parts += "; ";
-            parts += fmt::format("{} max {} chars", name, n);
-        };
-        add("title", sizes.title);
-        add("description", sizes.description);
-        add("meta_description", sizes.metaDescription);
-        return fmt::format("\n\nField size overrides (use these exact limits, in characters): {}.", parts);
+        return (n >= min && n <= max) ? n : 0;
     }
 
     // Reads the optional user-supplied prompt from the body. Non-string or empty
@@ -245,12 +249,10 @@ Return strictly valid JSON. Do not wrap in code fences.)";
                              const std::string &extraPrompt) {
         const std::string &dir = guard.dir();
 
-        const std::string prompt = getEnv("CLAUDE_ANALYZE_IMAGE_PROMPT", std::string(DEFAULT_PROMPT).c_str());
         const std::string fullPrompt = fmt::format(
-            "{}{}{}\n\nUse the Read tool to load the image at {} and then analyze it. Return ONLY the JSON object — "
+            "{}{}\n\nUse the Read tool to load the image at {} and then analyze it. Return ONLY the JSON object — "
             "no prose, no markdown fences, no explanation.",
-            prompt,
-            sizeOverrideBlock(sizes),
+            buildPrompt(sizes),
             extraPromptBlock(extraPrompt),
             imagePath);
 
@@ -320,9 +322,9 @@ void AiAnalyzeImage::analyze(const HttpRequestPtr &req, std::function<void(const
         return;
     }
 
-    const SizeOverrides sizes{.title = readSize(body, "title_size"),
-                              .description = readSize(body, "description_size"),
-                              .metaDescription = readSize(body, "meta_description_size")};
+    const SizeOverrides sizes{.title = readSize(body, "title_size", 10, 60),
+                              .description = readSize(body, "description_size", 50, 1000),
+                              .metaDescription = readSize(body, "meta_description_size", 50, 160)};
     const std::string extraPrompt = readExtraPrompt(body);
 
     const std::string decoded = Base64::Decode(image);

--- a/tests/TestAiAnalyzeImage.h
+++ b/tests/TestAiAnalyzeImage.h
@@ -173,32 +173,119 @@ TEST_F(AiAnalyzeImageTest, ClaudeBadJson502) {
     invoke(buildRequest(validBody()), expectStatusAndError(drogon::k502BadGateway, "Invalid JSON from claude"));
 }
 
-TEST_F(AiAnalyzeImageTest, NoSizeOverridesOmitsBlock) {
+TEST_F(AiAnalyzeImageTest, NoSizeOverridesKeepsDefaultWording) {
     const std::string prompt = promptFor(validBody());
     EXPECT_FALSE(prompt.empty());
-    EXPECT_EQ(prompt.find("Field size overrides"), std::string::npos);
+    EXPECT_EQ(prompt.find("approximately"), std::string::npos);
+    EXPECT_NE(prompt.find("short product title, 5-12 words"), std::string::npos);
+    EXPECT_NE(prompt.find("2-4 sentence engaging product description"), std::string::npos);
+    EXPECT_NE(prompt.find("SEO meta description, max 160 chars"), std::string::npos);
 }
 
 TEST_F(AiAnalyzeImageTest, DescriptionSizeOverrideInjected) {
     Json::Value body = validBody();
     body["description_size"] = 300;
     const std::string prompt = promptFor(body);
-    EXPECT_NE(prompt.find("Field size overrides"), std::string::npos);
-    EXPECT_NE(prompt.find("description max 300 chars"), std::string::npos);
-    // Fields that were not overridden must not appear in the override block.
-    EXPECT_EQ(prompt.find("title max"), std::string::npos);
-    EXPECT_EQ(prompt.find("meta_description max"), std::string::npos);
+    EXPECT_NE(prompt.find("engaging product description, approximately 300 characters"), std::string::npos);
+    // Other fields keep their default wording.
+    EXPECT_NE(prompt.find("short product title, 5-12 words"), std::string::npos);
+    EXPECT_NE(prompt.find("SEO meta description, max 160 chars"), std::string::npos);
 }
 
 TEST_F(AiAnalyzeImageTest, AllSizeOverridesInjected) {
     Json::Value body = validBody();
     body["title_size"] = 60;
     body["description_size"] = 300;
-    body["meta_description_size"] = 200;
+    body["meta_description_size"] = 150;
     const std::string prompt = promptFor(body);
-    EXPECT_NE(prompt.find("title max 60 chars"), std::string::npos);
-    EXPECT_NE(prompt.find("description max 300 chars"), std::string::npos);
-    EXPECT_NE(prompt.find("meta_description max 200 chars"), std::string::npos);
+    EXPECT_NE(prompt.find("product title, approximately 60 characters"), std::string::npos);
+    EXPECT_NE(prompt.find("engaging product description, approximately 300 characters"), std::string::npos);
+    EXPECT_NE(prompt.find("SEO meta description, approximately 150 characters"), std::string::npos);
+    // No default wording remains for the overridden fields.
+    EXPECT_EQ(prompt.find("5-12 words"), std::string::npos);
+    EXPECT_EQ(prompt.find("2-4 sentence"), std::string::npos);
+    EXPECT_EQ(prompt.find("max 160 chars"), std::string::npos);
+}
+
+TEST_F(AiAnalyzeImageTest, TitleSizeAboveMaxFallsBack) {
+    Json::Value body = validBody();
+    body["title_size"] = 200;  // > 60
+    const std::string prompt = promptFor(body);
+    EXPECT_EQ(prompt.find("title, approximately"), std::string::npos);
+    EXPECT_NE(prompt.find("short product title, 5-12 words"), std::string::npos);
+}
+
+TEST_F(AiAnalyzeImageTest, DescriptionSizeAboveMaxFallsBack) {
+    Json::Value body = validBody();
+    body["description_size"] = 5000;  // > 1000
+    const std::string prompt = promptFor(body);
+    EXPECT_EQ(prompt.find("description, approximately"), std::string::npos);
+    EXPECT_NE(prompt.find("2-4 sentence engaging product description"), std::string::npos);
+}
+
+TEST_F(AiAnalyzeImageTest, MetaDescriptionSizeAboveMaxFallsBack) {
+    Json::Value body = validBody();
+    body["meta_description_size"] = 500;  // > 160
+    const std::string prompt = promptFor(body);
+    EXPECT_EQ(prompt.find("meta description, approximately"), std::string::npos);
+    EXPECT_NE(prompt.find("SEO meta description, max 160 chars"), std::string::npos);
+}
+
+TEST_F(AiAnalyzeImageTest, TitleSizeBelowMinFallsBack) {
+    Json::Value body = validBody();
+    body["title_size"] = 3;  // < 10
+    const std::string prompt = promptFor(body);
+    EXPECT_EQ(prompt.find("title, approximately"), std::string::npos);
+    EXPECT_NE(prompt.find("short product title, 5-12 words"), std::string::npos);
+}
+
+TEST_F(AiAnalyzeImageTest, DescriptionSizeBelowMinFallsBack) {
+    Json::Value body = validBody();
+    body["description_size"] = 10;  // < 50
+    const std::string prompt = promptFor(body);
+    EXPECT_EQ(prompt.find("description, approximately"), std::string::npos);
+    EXPECT_NE(prompt.find("2-4 sentence engaging product description"), std::string::npos);
+}
+
+TEST_F(AiAnalyzeImageTest, MetaDescriptionSizeBelowMinFallsBack) {
+    Json::Value body = validBody();
+    body["meta_description_size"] = 10;  // < 50
+    const std::string prompt = promptFor(body);
+    EXPECT_EQ(prompt.find("meta description, approximately"), std::string::npos);
+    EXPECT_NE(prompt.find("SEO meta description, max 160 chars"), std::string::npos);
+}
+
+TEST_F(AiAnalyzeImageTest, TitleSizeBoundariesInject) {
+    Json::Value max = validBody();
+    max["title_size"] = 60;  // == max
+    EXPECT_NE(promptFor(max).find("product title, approximately 60 characters"), std::string::npos);
+
+    Json::Value min = validBody();
+    min["title_size"] = 10;  // == min
+    EXPECT_NE(promptFor(min).find("product title, approximately 10 characters"), std::string::npos);
+}
+
+TEST_F(AiAnalyzeImageTest, TitleSizeJustOutsideBoundariesFallBack) {
+    Json::Value over = validBody();
+    over["title_size"] = 61;  // max + 1
+    EXPECT_EQ(promptFor(over).find("title, approximately"), std::string::npos);
+
+    Json::Value under = validBody();
+    under["title_size"] = 9;  // min - 1
+    EXPECT_EQ(promptFor(under).find("title, approximately"), std::string::npos);
+}
+
+TEST_F(AiAnalyzeImageTest, MixedSizeOverridesInjectOnlyInRange) {
+    Json::Value body = validBody();
+    body["title_size"] = 50;  // in range → inject
+    body["description_size"] = 5000;  // out of range → fall back
+    // meta_description_size unset → fall back
+    const std::string prompt = promptFor(body);
+    EXPECT_NE(prompt.find("product title, approximately 50 characters"), std::string::npos);
+    EXPECT_NE(prompt.find("2-4 sentence engaging product description"), std::string::npos);
+    EXPECT_NE(prompt.find("SEO meta description, max 160 chars"), std::string::npos);
+    EXPECT_EQ(prompt.find("description, approximately"), std::string::npos);
+    EXPECT_EQ(prompt.find("meta description, approximately"), std::string::npos);
 }
 
 TEST_F(AiAnalyzeImageTest, NonPositiveSizeOverridesIgnored) {
@@ -206,14 +293,17 @@ TEST_F(AiAnalyzeImageTest, NonPositiveSizeOverridesIgnored) {
     body["title_size"] = 0;
     body["description_size"] = -10;
     const std::string prompt = promptFor(body);
-    EXPECT_EQ(prompt.find("Field size overrides"), std::string::npos);
+    EXPECT_EQ(prompt.find("approximately"), std::string::npos);
+    EXPECT_NE(prompt.find("short product title, 5-12 words"), std::string::npos);
+    EXPECT_NE(prompt.find("2-4 sentence engaging product description"), std::string::npos);
 }
 
 TEST_F(AiAnalyzeImageTest, NonNumericSizeOverrideIgnored) {
     Json::Value body = validBody();
     body["description_size"] = "not a number";
     const std::string prompt = promptFor(body);
-    EXPECT_EQ(prompt.find("Field size overrides"), std::string::npos);
+    EXPECT_EQ(prompt.find("approximately"), std::string::npos);
+    EXPECT_NE(prompt.find("2-4 sentence engaging product description"), std::string::npos);
 }
 
 TEST_F(AiAnalyzeImageTest, NoExtraPromptOmitsBlock) {
@@ -249,7 +339,7 @@ TEST_F(AiAnalyzeImageTest, ExtraPromptAppearsAfterSizeOverrides) {
     body["title_size"] = 60;
     body["extra_prompt"] = "Emphasize seasonal colors.";
     const std::string prompt = promptFor(body);
-    const auto sizePos = prompt.find("Field size overrides");
+    const auto sizePos = prompt.find("product title, approximately 60 characters");
     const auto extraPos = prompt.find("Additional instructions from the request");
     ASSERT_NE(sizePos, std::string::npos);
     ASSERT_NE(extraPos, std::string::npos);


### PR DESCRIPTION
## Summary

Replaces the appended **"Field size overrides"** block in `AiAnalyzeImage` with **direct inline injection** of size targets into the prompt's JSON-shape placeholders. Each overridden field now switches to `approximately N characters` (a *target*, enabling both shrinking and expanding) instead of a `max N` ceiling that fought the inline default wording.

## Changes

`src/code/controllers/AiAnalyzeImage.cpp`:
- Split `DEFAULT_PROMPT` into `PROMPT_PREFIX`/`PROMPT_SUFFIX` around the three placeholder lines; add `buildPrompt(sizes)` to assemble the prompt with per-field wording.
- `readSize()` now enforces per-field `[min, max]` bounds (title 10–60, description 50–1000, meta_description 50–160). Out-of-range / non-integral values fall back to the default wording for that field — no error returned.
- Delete `sizeOverrideBlock()` and the `CLAUDE_ANALYZE_IMAGE_PROMPT` env override; always use the templated default prompt.
- `extra_prompt` handling unchanged (still appended via `extraPromptBlock()`).

`tests/TestAiAnalyzeImage.h`:
- Rewrite the four size-override tests to the new inline wording; update the two fallback tests.
- Add per-field above-max, below-min, boundary, and mixed in-range/out-of-range/unset tests.

Also includes the design spec (`docs/.../specs/`) and implementation plan (`docs/.../plans/`).

## Testing

- Build: clean (`ninja-debug`).
- `ctest -R AiAnalyzeImage`: 24/24 pass.
- Full suite: 194/194 pass.

Closes #104

🤖 Generated with [Claude Code](https://claude.com/claude-code)