### PR TITLE
Promote dev to main: deploy environment gate fix

### DIFF
--- a/.github/workflows/_deploy.yml
+++ b/.github/workflows/_deploy.yml
@@ -1,0 +1,128 @@
+name: _deploy
+
+# Reusable deploy workflow. Called by deploy.yml with a literal environment
+# name per target so GitHub's deployment-branch-protection gate can resolve the
+# environment statically (a dynamic `environment:` expression defeats the gate
+# and makes a dev deploy get checked against prod's protection rules).
+
+on:
+  workflow_call:
+    inputs:
+      tag:
+        description: 'Image tag / branch to deploy'
+        required: true
+        type: string
+      env_name:
+        description: 'GitHub environment to deploy to (dev or prod)'
+        required: true
+        type: string
+    secrets:
+      CR_PAT:
+        required: true
+      DEPLOY_SSH_KEY:
+        required: true
+      DEPLOY_SSH_KNOWN_HOSTS:
+        required: true
+      DEPLOY_USER:
+        required: true
+      DEPLOY_HOST:
+        required: true
+      FOXY_CLIENT:
+        required: true
+      FOXY_ADMIN:
+        required: true
+      APP_CLOUD_NAME:
+        required: true
+      APP_BUCKET_HOST:
+        required: true
+      PINTEREST_API_HOST:
+        required: true
+      PINTEREST_BOARD_ID:
+        required: true
+      PINTEREST_CLIENT_ID:
+        required: true
+      PINTEREST_CLIENT_SECRET:
+        required: true
+      YOUTUBE_REFRESH_TOKEN:
+        required: true
+      YOUTUBE_CLIENT_ID:
+        required: true
+      YOUTUBE_CLIENT_SECRET:
+        required: true
+      TWITTER_API_KEY:
+        required: true
+      TWITTER_API_SECRET:
+        required: true
+      TWITTER_ACCESS_TOKEN:
+        required: true
+      TWITTER_ACCESS_TOKEN_SECRET:
+        required: true
+      TWITTER_BEARER_TOKEN:
+        required: true
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    environment: ${{ inputs.env_name }}
+
+    steps:
+      - name: Login to GitHub Container Registry
+        env:
+          CR_PAT: ${{ secrets.CR_PAT }}
+        run: echo "${CR_PAT}" | docker login ghcr.io -u spiritEcosse --password-stdin
+
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup SSH agent
+        uses: webfactory/ssh-agent@dc588b651fe13675774614f8e6a936a468676387 # v0.9.0
+        with:
+          ssh-private-key: ${{ secrets.DEPLOY_SSH_KEY }}
+
+      - name: Add known hosts
+        env:
+          KNOWN_HOSTS: ${{ secrets.DEPLOY_SSH_KNOWN_HOSTS }}
+        run: echo "${KNOWN_HOSTS}" >> ~/.ssh/known_hosts
+
+      - name: Set up Docker context
+        env:
+          DEPLOY_USER: ${{ secrets.DEPLOY_USER }}
+          DEPLOY_HOST: ${{ secrets.DEPLOY_HOST }}
+        run: |
+          docker context create remote \
+            --docker "host=ssh://${DEPLOY_USER}@${DEPLOY_HOST}"
+          docker context use remote
+
+      - name: Pull latest image
+        env:
+          TAG: ${{ inputs.tag }}
+        run: docker pull "ghcr.io/spiritecosse/foxy_server:${TAG}"
+
+      - name: Deploy
+        env:
+          FOXY_CLIENT: ${{ secrets.FOXY_CLIENT }}
+          FOXY_ADMIN: ${{ secrets.FOXY_ADMIN }}
+          APP_CLOUD_NAME: ${{ secrets.APP_CLOUD_NAME }}
+          APP_BUCKET_HOST: ${{ secrets.APP_BUCKET_HOST }}
+          PINTEREST_API_HOST: ${{ secrets.PINTEREST_API_HOST }}
+          PINTEREST_BOARD_ID: ${{ secrets.PINTEREST_BOARD_ID }}
+          PINTEREST_CLIENT_ID: ${{ secrets.PINTEREST_CLIENT_ID }}
+          PINTEREST_CLIENT_SECRET: ${{ secrets.PINTEREST_CLIENT_SECRET }}
+          YOUTUBE_REFRESH_TOKEN: ${{ secrets.YOUTUBE_REFRESH_TOKEN }}
+          YOUTUBE_CLIENT_ID: ${{ secrets.YOUTUBE_CLIENT_ID }}
+          YOUTUBE_CLIENT_SECRET: ${{ secrets.YOUTUBE_CLIENT_SECRET }}
+          TWITTER_API_KEY: ${{ secrets.TWITTER_API_KEY }}
+          TWITTER_API_SECRET: ${{ secrets.TWITTER_API_SECRET }}
+          TWITTER_ACCESS_TOKEN: ${{ secrets.TWITTER_ACCESS_TOKEN }}
+          TWITTER_ACCESS_TOKEN_SECRET: ${{ secrets.TWITTER_ACCESS_TOKEN_SECRET }}
+          TWITTER_BEARER_TOKEN: ${{ secrets.TWITTER_BEARER_TOKEN }}
+          PROFILE: ${{ vars.PROFILE }}
+          HOST: ${{ vars.HOST }}
+          TAG: ${{ inputs.tag }}
+        run: |
+          echo "Deploying profile=$PROFILE tag=$TAG host=$HOST"
+          docker compose -p foxy-${PROFILE} up -d --wait foxy
+
+      - name: Prune unused images
+        if: always()
+        run: docker image prune -f

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -13,67 +13,64 @@ on:
         default: 'dev'
 
 jobs:
-  deploy:
-    if: github.event_name == 'workflow_dispatch' || github.event.workflow_run.conclusion == 'success'
-    runs-on: ubuntu-latest
-    environment: ${{ (github.event.workflow_run.head_branch || github.event.inputs.branch) == 'main' && 'prod' || 'dev' }}
+  deploy-dev:
+    if: >
+      (github.event_name == 'workflow_dispatch' && github.event.inputs.branch == 'dev') ||
+      (github.event_name == 'workflow_run' && github.event.workflow_run.conclusion == 'success' && github.event.workflow_run.head_branch == 'dev')
+    uses: ./.github/workflows/_deploy.yml
+    with:
+      tag: dev
+      env_name: dev
+    secrets:
+      CR_PAT: ${{ secrets.CR_PAT }}
+      DEPLOY_SSH_KEY: ${{ secrets.DEPLOY_SSH_KEY }}
+      DEPLOY_SSH_KNOWN_HOSTS: ${{ secrets.DEPLOY_SSH_KNOWN_HOSTS }}
+      DEPLOY_USER: ${{ secrets.DEPLOY_USER }}
+      DEPLOY_HOST: ${{ secrets.DEPLOY_HOST }}
+      FOXY_CLIENT: ${{ secrets.FOXY_CLIENT }}
+      FOXY_ADMIN: ${{ secrets.FOXY_ADMIN }}
+      APP_CLOUD_NAME: ${{ secrets.APP_CLOUD_NAME }}
+      APP_BUCKET_HOST: ${{ secrets.APP_BUCKET_HOST }}
+      PINTEREST_API_HOST: ${{ secrets.PINTEREST_API_HOST }}
+      PINTEREST_BOARD_ID: ${{ secrets.PINTEREST_BOARD_ID }}
+      PINTEREST_CLIENT_ID: ${{ secrets.PINTEREST_CLIENT_ID }}
+      PINTEREST_CLIENT_SECRET: ${{ secrets.PINTEREST_CLIENT_SECRET }}
+      YOUTUBE_REFRESH_TOKEN: ${{ secrets.YOUTUBE_REFRESH_TOKEN }}
+      YOUTUBE_CLIENT_ID: ${{ secrets.YOUTUBE_CLIENT_ID }}
+      YOUTUBE_CLIENT_SECRET: ${{ secrets.YOUTUBE_CLIENT_SECRET }}
+      TWITTER_API_KEY: ${{ secrets.TWITTER_API_KEY }}
+      TWITTER_API_SECRET: ${{ secrets.TWITTER_API_SECRET }}
+      TWITTER_ACCESS_TOKEN: ${{ secrets.TWITTER_ACCESS_TOKEN }}
+      TWITTER_ACCESS_TOKEN_SECRET: ${{ secrets.TWITTER_ACCESS_TOKEN_SECRET }}
+      TWITTER_BEARER_TOKEN: ${{ secrets.TWITTER_BEARER_TOKEN }}
 
-    steps:
-      - name: Login to GitHub Container Registry
-        run: echo "${{ secrets.CR_PAT }}" | docker login ghcr.io -u spiritEcosse --password-stdin
-
-      - name: Checkout repository
-        uses: actions/checkout@v4
-
-      - name: Extract branch name
-        env:
-          HEAD_BRANCH: ${{ github.event.workflow_run.head_branch || github.event.inputs.branch }}
-        run: echo "BRANCH_NAME=${HEAD_BRANCH}" >> $GITHUB_ENV
-
-      - name: Setup SSH agent
-        uses: webfactory/ssh-agent@v0.9.0
-        with:
-          ssh-private-key: ${{ secrets.DEPLOY_SSH_KEY }}
-
-      - name: Add known hosts
-        env:
-          KNOWN_HOSTS: ${{ secrets.DEPLOY_SSH_KNOWN_HOSTS }}
-        run: echo "${KNOWN_HOSTS}" >> ~/.ssh/known_hosts
-
-      - name: Set up Docker context
-        run: |
-          docker context create remote \
-            --docker "host=ssh://${{ secrets.DEPLOY_USER }}@${{ secrets.DEPLOY_HOST }}"
-          docker context use remote
-
-      - name: Pull latest image
-        run: docker pull ghcr.io/spiritecosse/foxy_server:${BRANCH_NAME}
-
-      - name: Deploy
-        env:
-          FOXY_CLIENT: ${{ secrets.FOXY_CLIENT }}
-          FOXY_ADMIN: ${{ secrets.FOXY_ADMIN }}
-          APP_CLOUD_NAME: ${{ secrets.APP_CLOUD_NAME }}
-          APP_BUCKET_HOST: ${{ secrets.APP_BUCKET_HOST }}
-          PINTEREST_API_HOST: ${{ secrets.PINTEREST_API_HOST }}
-          PINTEREST_BOARD_ID: ${{ secrets.PINTEREST_BOARD_ID }}
-          PINTEREST_CLIENT_ID: ${{ secrets.PINTEREST_CLIENT_ID }}
-          PINTEREST_CLIENT_SECRET: ${{ secrets.PINTEREST_CLIENT_SECRET }}
-          YOUTUBE_REFRESH_TOKEN: ${{ secrets.YOUTUBE_REFRESH_TOKEN }}
-          YOUTUBE_CLIENT_ID: ${{ secrets.YOUTUBE_CLIENT_ID }}
-          YOUTUBE_CLIENT_SECRET: ${{ secrets.YOUTUBE_CLIENT_SECRET }}
-          TWITTER_API_KEY: ${{ secrets.TWITTER_API_KEY }}
-          TWITTER_API_SECRET: ${{ secrets.TWITTER_API_SECRET }}
-          TWITTER_ACCESS_TOKEN: ${{ secrets.TWITTER_ACCESS_TOKEN }}
-          TWITTER_ACCESS_TOKEN_SECRET: ${{ secrets.TWITTER_ACCESS_TOKEN_SECRET }}
-          TWITTER_BEARER_TOKEN: ${{ secrets.TWITTER_BEARER_TOKEN }}
-          PROFILE: ${{ vars.PROFILE }}
-          HOST: ${{ vars.HOST }}
-          TAG: ${{ env.BRANCH_NAME }}
-        run: |
-          echo "Deploying profile=$PROFILE tag=$TAG host=$HOST"
-          docker compose -p foxy-${PROFILE} up -d --wait foxy
-
-      - name: Prune unused images
-        if: always()
-        run: docker image prune -f
+  deploy-prod:
+    if: >
+      (github.event_name == 'workflow_dispatch' && github.event.inputs.branch == 'main') ||
+      (github.event_name == 'workflow_run' && github.event.workflow_run.conclusion == 'success' && github.event.workflow_run.head_branch == 'main')
+    uses: ./.github/workflows/_deploy.yml
+    with:
+      tag: main
+      env_name: prod
+    secrets:
+      CR_PAT: ${{ secrets.CR_PAT }}
+      DEPLOY_SSH_KEY: ${{ secrets.DEPLOY_SSH_KEY }}
+      DEPLOY_SSH_KNOWN_HOSTS: ${{ secrets.DEPLOY_SSH_KNOWN_HOSTS }}
+      DEPLOY_USER: ${{ secrets.DEPLOY_USER }}
+      DEPLOY_HOST: ${{ secrets.DEPLOY_HOST }}
+      FOXY_CLIENT: ${{ secrets.FOXY_CLIENT }}
+      FOXY_ADMIN: ${{ secrets.FOXY_ADMIN }}
+      APP_CLOUD_NAME: ${{ secrets.APP_CLOUD_NAME }}
+      APP_BUCKET_HOST: ${{ secrets.APP_BUCKET_HOST }}
+      PINTEREST_API_HOST: ${{ secrets.PINTEREST_API_HOST }}
+      PINTEREST_BOARD_ID: ${{ secrets.PINTEREST_BOARD_ID }}
+      PINTEREST_CLIENT_ID: ${{ secrets.PINTEREST_CLIENT_ID }}
+      PINTEREST_CLIENT_SECRET: ${{ secrets.PINTEREST_CLIENT_SECRET }}
+      YOUTUBE_REFRESH_TOKEN: ${{ secrets.YOUTUBE_REFRESH_TOKEN }}
+      YOUTUBE_CLIENT_ID: ${{ secrets.YOUTUBE_CLIENT_ID }}
+      YOUTUBE_CLIENT_SECRET: ${{ secrets.YOUTUBE_CLIENT_SECRET }}
+      TWITTER_API_KEY: ${{ secrets.TWITTER_API_KEY }}
+      TWITTER_API_SECRET: ${{ secrets.TWITTER_API_SECRET }}
+      TWITTER_ACCESS_TOKEN: ${{ secrets.TWITTER_ACCESS_TOKEN }}
+      TWITTER_ACCESS_TOKEN_SECRET: ${{ secrets.TWITTER_ACCESS_TOKEN_SECRET }}
+      TWITTER_BEARER_TOKEN: ${{ secrets.TWITTER_BEARER_TOKEN }}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -154,7 +154,7 @@ Custom query builder — not Drogon's built-in ORM:
 - **After creating a PR**: Wait 30 seconds, then run `sonar list issues --project spiritEcosse_foxy_server --pull-request <N> --format table`. If there are **zero issues** on new code, check CI jobs with `gh pr checks <PR#> --watch`. Only merge after **both** SonarCloud gate AND all CI jobs (ninja-debug, ninja-asan-ubsan, ninja-tsan) pass (`gh pr merge --squash`). If ANY SonarCloud issues or CI failures, fix them all, push, and re-check until clean.
 - **Close issue after merge**: After merging a feature branch into `dev`, ALWAYS close the issue with `gh issue close <N>`. Do NOT wait to be asked.
 - **Switch to dev after merge**: After merging and closing the issue, ALWAYS run `git checkout dev && git pull` to return to the main branch.
-- **Ad-hoc fixes** (no GitHub Issue): Work directly on `dev`.
+- **Ad-hoc fixes** (no GitHub Issue): `dev` and `main` are protected — direct pushes are blocked. Create a feature branch (e.g. `git checkout -b fix/<short-description>`), push it, and open a PR with `gh pr create --base dev`. All changes reach `dev`/`main` via PR.
 
 Before implementing any feature or fix: if a GitHub issue exists for it, create a branch using `gh issue develop` as described above.
 


### PR DESCRIPTION
## Summary

Promote `dev` to `main` (production). Single change: the deploy workflow
rework that fixes the environment-protection gate.

- `deploy.yml` is now a thin caller with two branch-gated jobs passing a
  literal `env_name` (dev->dev, main->prod), via reusable `_deploy.yml`.
- Fixes the failure where a deploy was checked against prod's protection
  rules regardless of branch.
- SonarCloud security hotspots on the workflows resolved in code (SHA-pinned
  action, explicit least-privilege secrets, secrets via env vars).

Merging this triggers the **prod** deploy path (`deploy-prod`) for the
first time under the new workflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)