### PR TITLE
feat: add collections for items (many-to-many)

### DIFF
--- a/fixtures.sql
+++ b/fixtures.sql
@@ -87,5 +87,16 @@ $$
         INSERT INTO pinterest_token (access_token, access_token_expires_at, refresh_token, refresh_token_expires_at, scope)
         VALUES ('fixture_access_token', '2099-01-01 00:00:00+00', 'fixture_refresh_token', '2099-12-31 00:00:00+00',
                 'pins:read,pins:write,user_accounts:read,boards:read,boards:write');
+
+-- Mock data for collection
+        INSERT INTO collection (title, slug, description, meta_description, enabled)
+        VALUES ('Collection1', 'collection1', 'Description1', 'Meta1', true),
+               ('Collection2', 'collection2', 'Description2', 'Meta2', false);
+
+-- Mock data for collection_item (item 1 appears in both collections)
+        INSERT INTO collection_item (collection_id, item_id)
+        VALUES (1, 1),
+               (1, 2),
+               (2, 1);
     END
 $$;

--- a/fixtures.sql
+++ b/fixtures.sql
@@ -90,8 +90,8 @@ $$
 
 -- Mock data for collection
         INSERT INTO collection (title, slug, description, meta_description, enabled)
-        VALUES ('Collection1', 'collection1', 'Description1', 'Meta1', true),
-               ('Collection2', 'collection2', 'Description2', 'Meta2', false);
+        VALUES ('Collection1', 'collection1', 'Collection description 1', 'Collection meta 1', true),
+               ('Collection2', 'collection2', 'Collection description 2', 'Collection meta 2', false);
 
 -- Mock data for collection_item (item 1 appears in both collections)
         INSERT INTO collection_item (collection_id, item_id)

--- a/migrations/20260608142303_add_collection.sql
+++ b/migrations/20260608142303_add_collection.sql
@@ -1,13 +1,13 @@
 CREATE TABLE collection
 (
     id               SERIAL PRIMARY KEY,
-    title            VARCHAR(255) NOT NULL,
-    slug             VARCHAR(255) NOT NULL UNIQUE,
-    description      TEXT         NOT NULL,
-    meta_description VARCHAR(255) NOT NULL,
-    enabled          BOOLEAN      NOT NULL DEFAULT FALSE,
-    created_at       TIMESTAMPTZ  NOT NULL DEFAULT NOW(),
-    updated_at       TIMESTAMPTZ  NOT NULL DEFAULT NOW()
+    title            TEXT        NOT NULL,
+    slug             TEXT        NOT NULL UNIQUE,
+    description      TEXT        NOT NULL,
+    meta_description TEXT        NOT NULL,
+    enabled          BOOLEAN     NOT NULL DEFAULT FALSE,
+    created_at       TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at       TIMESTAMPTZ NOT NULL DEFAULT NOW()
 );
 
 CREATE INDEX idx_collection_enabled ON collection (enabled);

--- a/migrations/20260608142303_add_collection.sql
+++ b/migrations/20260608142303_add_collection.sql
@@ -1,0 +1,17 @@
+CREATE TABLE collection
+(
+    id               SERIAL PRIMARY KEY,
+    title            VARCHAR(255) NOT NULL,
+    slug             VARCHAR(255) NOT NULL UNIQUE,
+    description      TEXT         NOT NULL,
+    meta_description VARCHAR(255) NOT NULL,
+    enabled          BOOLEAN      NOT NULL DEFAULT FALSE,
+    created_at       TIMESTAMPTZ  NOT NULL DEFAULT NOW(),
+    updated_at       TIMESTAMPTZ  NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX idx_collection_enabled ON collection (enabled);
+
+CREATE TRIGGER set_collection_timestamp
+    BEFORE UPDATE ON collection
+    FOR EACH ROW EXECUTE FUNCTION trigger_set_timestamp();

--- a/migrations/20260608142309_add_collection_item.sql
+++ b/migrations/20260608142309_add_collection_item.sql
@@ -1,0 +1,17 @@
+CREATE TABLE collection_item
+(
+    id            SERIAL PRIMARY KEY,
+    collection_id INT         NOT NULL,
+    item_id       INT         NOT NULL,
+    created_at    TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at    TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    FOREIGN KEY (collection_id) REFERENCES collection (id) ON DELETE CASCADE,
+    FOREIGN KEY (item_id) REFERENCES item (id) ON DELETE CASCADE,
+    UNIQUE (collection_id, item_id)
+);
+
+CREATE INDEX idx_collection_item_item_id ON collection_item (item_id);
+
+CREATE TRIGGER set_collection_item_timestamp
+    BEFORE UPDATE ON collection_item
+    FOR EACH ROW EXECUTE FUNCTION trigger_set_timestamp();

--- a/migrations/atlas.sum
+++ b/migrations/atlas.sum
@@ -1,3 +1,5 @@
-h1:e7J1LGp11pd2HxS26zI+OtgRfNirvoypSomGxvgTpFg=
+h1:IBIBlR4Ihg1ykbye1WLbflTzWNc05r/MbLZspv8FBXQ=
 20260101000000_baseline.sql h1:IZWmzt7S367C+Tu9A5PvxwbhI4H6lYxjA4ya8ZQtpG4=
 20260225110739_add_pinterest_token.sql h1:2duFO0FRU4wH7n+hLFgARXHZ0CUA9v87ZnAdlgtrlGQ=
+20260608142303_add_collection.sql h1:YrBiutKvQ5/R5q/YcpwG4dSyY0b+kzOObZJseJWWXUg=
+20260608142309_add_collection_item.sql h1:+eGzrmBFzr8LdbNdKsOeHTKjjsMHeEYkXwnTmHbkyb4=

--- a/migrations/atlas.sum
+++ b/migrations/atlas.sum
@@ -1,5 +1,5 @@
-h1:IBIBlR4Ihg1ykbye1WLbflTzWNc05r/MbLZspv8FBXQ=
+h1:eIgys51poMsqer73hoC1IQJ1ur82a2wy3v2M+8+0MTg=
 20260101000000_baseline.sql h1:IZWmzt7S367C+Tu9A5PvxwbhI4H6lYxjA4ya8ZQtpG4=
 20260225110739_add_pinterest_token.sql h1:2duFO0FRU4wH7n+hLFgARXHZ0CUA9v87ZnAdlgtrlGQ=
-20260608142303_add_collection.sql h1:YrBiutKvQ5/R5q/YcpwG4dSyY0b+kzOObZJseJWWXUg=
-20260608142309_add_collection_item.sql h1:+eGzrmBFzr8LdbNdKsOeHTKjjsMHeEYkXwnTmHbkyb4=
+20260608142303_add_collection.sql h1:qw7k1NcG2/rCkZsUSEpoL+w+6hCDy39nue1CllBiiYM=
+20260608142309_add_collection_item.sql h1:qOhBa5Rkxyxg5rqQbRKImQXuFozPk8Nv8Hgnn/ho0dA=

--- a/src/code/controllers/Collection.cpp
+++ b/src/code/controllers/Collection.cpp
@@ -1,0 +1,60 @@
+#include "controllers/Collection.h"
+#include "utils/request/Request.h"
+#include "orm/QuerySet.h"
+#include "models/ItemModel.h"
+#include "models/CollectionItemModel.h"
+#include "utils/config.h"
+#include <fmt/core.h>
+
+using namespace api::v1;
+using namespace drogon::orm;
+
+void Collection::getOne(const drogon::HttpRequestPtr &req,
+                        std::function<void(const drogon::HttpResponsePtr &)> &&callback,
+                        std::string &&stringId) const {
+    const auto callbackPtr =
+        std::make_shared<std::function<void(const drogon::HttpResponsePtr &)>>(std::move(callback));
+
+    // Public access is slug-only: reject numeric ids so collections cannot be probed by sequential id.
+    if(const auto resp = check404(req, canBeInt(stringId))) {
+        (*callbackPtr)(resp);
+        return;
+    }
+
+    const std::string query = CollectionModel().sqlSelectOne(&CollectionModel::Field::slug, std::move(stringId), {});
+    executeSqlQuery(callbackPtr, query);
+}
+
+void Collection::getListAdmin(const drogon::HttpRequestPtr &req,
+                              std::function<void(const drogon::HttpResponsePtr &)> &&callback) const {
+    const auto callbackPtr =
+        std::make_shared<std::function<void(const drogon::HttpResponsePtr &)>>(std::move(callback));
+    const int page = getInt(req->getParameter("page"), 1);
+    int limit = getInt(req->getParameter("limit"), 25);
+    auto qsPage = CollectionModel::qsPage(page, limit);
+
+    QuerySet<CollectionModel> qs(limit, "data");
+    qs.order_by(&BaseModel<CollectionModel>::Field::updatedAt, false)
+        .order_by(&BaseModel<CollectionModel>::Field::id, false)
+        .only(CollectionModel::allSetFields())
+        .offset(fmt::format("((SELECT * FROM {}) - 1) * {}", qsPage.alias(), limit));
+
+    executeSqlQuery(callbackPtr,
+                    BuildComplexQueries::buildQuery(CollectionModel::qsCount(), std::move(qsPage), std::move(qs)));
+}
+
+void Collection::getOneAdmin(const drogon::HttpRequestPtr &req,
+                             std::function<void(const drogon::HttpResponsePtr &)> &&callback,
+                             std::string &&stringId) const {
+    const auto callbackPtr =
+        std::make_shared<std::function<void(const drogon::HttpResponsePtr &)>>(std::move(callback));
+
+    if(const auto resp = check404(req, !canBeInt(stringId))) {
+        (*callbackPtr)(resp);
+        return;
+    }
+
+    const std::string query =
+        CollectionModel().sqlSelectOne(&BaseModel<CollectionModel>::Field::id, std::move(stringId), {});
+    executeSqlQuery(callbackPtr, query);
+}

--- a/src/code/controllers/Collection.h
+++ b/src/code/controllers/Collection.h
@@ -1,0 +1,49 @@
+#pragma once
+
+#include <drogon/drogon.h>
+#include "drogon/HttpController.h"
+#include "BaseCRUD.h"
+#include "models/CollectionModel.h"
+
+namespace api::v1 {
+
+    class Collection final : public drogon::HttpController<Collection>, public BaseCRUD<CollectionModel, Collection> {
+    public:
+        METHOD_LIST_BEGIN
+        METHOD_ADD(Collection::getList, "", drogon::Get, drogon::Options);
+        METHOD_ADD(Collection::getOne, "{1}", drogon::Get, drogon::Options);
+        METHOD_ADD(Collection::getListAdmin,
+                   "admin",
+                   drogon::Get,
+                   drogon::Options,
+                   "api::v1::filters::JwtGoogleFilter");
+        METHOD_ADD(Collection::getOneAdmin,
+                   "admin/{1}",
+                   drogon::Get,
+                   drogon::Options,
+                   "api::v1::filters::JwtGoogleFilter");
+        METHOD_ADD(Collection::createItem, "admin", drogon::Post, drogon::Options, "api::v1::filters::JwtGoogleFilter");
+        METHOD_ADD(Collection::updateItem,
+                   "admin/{1}",
+                   drogon::Put,
+                   drogon::Options,
+                   "api::v1::filters::JwtGoogleFilter");
+        METHOD_ADD(Collection::deleteItem,
+                   "admin/{1}",
+                   drogon::Delete,
+                   drogon::Options,
+                   "api::v1::filters::JwtGoogleFilter");
+        METHOD_LIST_END
+
+        // Public lookup is slug-only: a numeric / non-slug id must 404, never resolve by id.
+        void getOne(const drogon::HttpRequestPtr &req,
+                    std::function<void(const drogon::HttpResponsePtr &)> &&callback,
+                    std::string &&stringId) const override;
+
+        void getListAdmin(const drogon::HttpRequestPtr &req,
+                          std::function<void(const drogon::HttpResponsePtr &)> &&callback) const;
+        void getOneAdmin(const drogon::HttpRequestPtr &req,
+                         std::function<void(const drogon::HttpResponsePtr &)> &&callback,
+                         std::string &&stringId) const;
+    };
+}

--- a/src/code/controllers/CollectionItem.cpp
+++ b/src/code/controllers/CollectionItem.cpp
@@ -1,0 +1,1 @@
+#include "controllers/CollectionItem.h"

--- a/src/code/controllers/CollectionItem.h
+++ b/src/code/controllers/CollectionItem.h
@@ -1,0 +1,32 @@
+#pragma once
+
+#include <drogon/drogon.h>
+#include "drogon/HttpController.h"
+#include "BaseCRUD.h"
+#include "models/CollectionItemModel.h"
+
+namespace api::v1 {
+
+    class CollectionItem final : public drogon::HttpController<CollectionItem>,
+                                 public BaseCRUD<CollectionItemModel, CollectionItem> {
+    public:
+        METHOD_LIST_BEGIN
+        METHOD_ADD(CollectionItem::getList, "admin", drogon::Get, drogon::Options, "api::v1::filters::JwtGoogleFilter");
+        METHOD_ADD(CollectionItem::createItems,
+                   "admin/items",
+                   drogon::Post,
+                   drogon::Options,
+                   "api::v1::filters::JwtGoogleFilter");
+        METHOD_ADD(CollectionItem::updateItems,
+                   "admin/items",
+                   drogon::Put,
+                   drogon::Options,
+                   "api::v1::filters::JwtGoogleFilter");
+        METHOD_ADD(CollectionItem::deleteItems,
+                   "admin/items",
+                   drogon::Delete,
+                   drogon::Options,
+                   "api::v1::filters::JwtGoogleFilter");
+        METHOD_LIST_END
+    };
+}

--- a/src/code/models/CollectionItemModel.cpp
+++ b/src/code/models/CollectionItemModel.cpp
@@ -1,0 +1,14 @@
+#include "models/CollectionItemModel.h"
+#include "models/ItemModel.h"
+#include "models/CollectionModel.h"
+
+using namespace api::v1;
+
+BaseModelImpl::JoinMap CollectionItemModel::joinMap() {
+    return {{ItemModel::tableName, {&Field::itemId, &BaseModel<ItemModel>::Field::id}},
+            {CollectionModel::tableName, {&Field::collectionId, &BaseModel<CollectionModel>::Field::id}}};
+}
+
+BaseModel<CollectionItemModel>::SetMapFieldTypes CollectionItemModel::getObjectValues() const {
+    return {{&Field::collectionId, collectionId}, {&Field::itemId, itemId}};
+}

--- a/src/code/models/CollectionItemModel.h
+++ b/src/code/models/CollectionItemModel.h
@@ -1,0 +1,38 @@
+#pragma once
+
+#include <string>
+#include "models/BaseModel.h"
+
+namespace api::v1 {
+
+    class CollectionItemModel final : public BaseModel<CollectionItemModel> {
+    public:
+        using BaseModel::BaseModel;
+
+        static const inline std::string tableName = "collection_item";
+
+        struct Field : BaseModel::Field {
+            static inline const auto collectionId = BaseField("collection_id", tableName);
+            static inline const auto itemId = BaseField("item_id", tableName);
+
+            Field() : BaseModel::Field() {
+                constexpr std::array fields{&collectionId, &itemId};
+                registerFields(fields);
+            }
+        };
+
+        int collectionId{};
+        int itemId{};
+
+        explicit CollectionItemModel(const Json::Value &json) : BaseModel(json) {
+            collectionId = json[Field::collectionId.getFieldName()].asInt();
+            itemId = json[Field::itemId.getFieldName()].asInt();
+
+            validateField(Field::collectionId.getFieldName(), collectionId, missingFields);
+            validateField(Field::itemId.getFieldName(), itemId, missingFields);
+        }
+
+        [[nodiscard]] SetMapFieldTypes getObjectValues() const;
+        [[nodiscard]] static JoinMap joinMap();
+    };
+}

--- a/src/code/models/CollectionModel.cpp
+++ b/src/code/models/CollectionModel.cpp
@@ -1,0 +1,60 @@
+#include "models/CollectionModel.h"
+#include "models/ItemModel.h"
+#include "models/CollectionItemModel.h"
+#include "orm/QuerySet.h"
+#include "utils/db/StringUtils.h"
+#include <fmt/core.h>
+
+using namespace api::v1;
+
+BaseModelImpl::JoinMap CollectionModel::joinMap() {
+    return {{CollectionItemModel::tableName, {&BaseModel::Field::id, &CollectionItemModel::Field::collectionId}}};
+}
+
+BaseModel<CollectionModel>::SetMapFieldTypes CollectionModel::getObjectValues() const {
+    return {{&Field::title, title},
+            {&Field::slug, slug},
+            {&Field::description, description},
+            {&Field::metaDescription, metaDescription},
+            {&Field::enabled, enabled}};
+}
+
+QuerySet<CollectionModel> CollectionModel::qsCount() {
+    QuerySet<CollectionModel> qsCount("total", false, true);
+    return std::move(qsCount.filter(&Field::enabled, true).functions(Function("count(*)::integer")));
+}
+
+std::string
+CollectionModel::sqlSelectList(const int page,
+                               int limit,
+                               [[maybe_unused]] const std::map<std::string, std::string, std::less<>> &params) {
+    const auto &orderByCollection = &BaseModel::Field::updatedAt;
+    auto qsPage = CollectionModel::qsPage(page, limit);
+
+    QuerySet<CollectionModel> qs(limit, "data");
+    qs.filter(&Field::enabled, true)
+        .order_by(orderByCollection, false)
+        .order_by(&BaseModel::Field::id, false)
+        .only(allSetFields())
+        .offset(fmt::format("((SELECT * FROM {}) - 1) * {}", qsPage.alias(), limit));
+    return BuildComplexQueries::buildQuery(qsCount(), std::move(qsPage), std::move(qs));
+}
+
+std::string
+CollectionModel::sqlSelectOne(const BaseField *field,
+                              std::string &&value,
+                              [[maybe_unused]] const std::map<std::string, std::string, std::less<>> &params) {
+    QuerySet<ItemModel> qsItems(0, ItemModel::tableName, false);
+    qsItems.join<CollectionItemModel>()
+        .filter(&CollectionItemModel::Field::collectionId, &BaseModel::Field::id)
+        .functions(Function(
+            fmt::format("json_agg(json_build_object({}) ORDER BY item.id ASC)", ItemModel().fieldsJsonObject())));
+
+    QuerySet<CollectionModel> qsCollection(tableName, true, true);
+    qsCollection.filter(field, std::move(value))
+        .jsonFields(addExtraQuotes(fieldsJsonObject()))
+        .functions(
+            Function(addExtraQuotes(fmt::format(R"( 'items', COALESCE(({}), '[]'::json))", qsItems.buildSelect()))));
+
+    return qsCollection.buildSelectOne();
+}

--- a/src/code/models/CollectionModel.h
+++ b/src/code/models/CollectionModel.h
@@ -1,0 +1,55 @@
+#pragma once
+
+#include <string>
+#include "models/BaseModel.h"
+
+namespace api::v1 {
+
+    class CollectionModel final : public BaseModel<CollectionModel> {
+    public:
+        using BaseModel::BaseModel;
+        static const inline std::string tableName = "collection";
+
+        struct Field : BaseModel::Field {
+            static inline const auto title = BaseField("title", tableName);
+            static inline const auto slug = BaseField("slug", tableName);
+            static inline const auto description = BaseField("description", tableName);
+            static inline const auto metaDescription = BaseField("meta_description", tableName);
+            static inline const auto enabled = BaseField("enabled", tableName);
+
+            Field() : BaseModel::Field() {
+                constexpr std::array fields{&title, &slug, &description, &metaDescription, &enabled};
+                registerFields(fields);
+            }
+        };
+
+        std::string title;
+        std::string slug;
+        std::string description;
+        std::string metaDescription;
+        bool enabled = false;
+
+        explicit CollectionModel(const Json::Value &json) : BaseModel(json) {
+            title = json[Field::title.getFieldName()].asString();
+            slug = json[Field::slug.getFieldName()].asString();
+            description = json[Field::description.getFieldName()].asString();
+            metaDescription = json[Field::metaDescription.getFieldName()].asString();
+            enabled = json[Field::enabled.getFieldName()].asBool();
+
+            validateField(Field::title.getFieldName(), title, missingFields);
+            validateField(Field::slug.getFieldName(), slug, missingFields);
+            validateField(Field::description.getFieldName(), description, missingFields);
+            validateField(Field::metaDescription.getFieldName(), metaDescription, missingFields);
+        }
+
+        [[nodiscard]] static QuerySet<CollectionModel> qsCount();
+
+        [[nodiscard]] SetMapFieldTypes getObjectValues() const;
+        [[nodiscard]] static std::string
+        sqlSelectList(int page, int limit, const std::map<std::string, std::string, std::less<>> &params);
+        [[nodiscard]] std::string sqlSelectOne(const BaseField *field,
+                                               std::string &&value,
+                                               const std::map<std::string, std::string, std::less<>> &params) override;
+        [[nodiscard]] static JoinMap joinMap();
+    };
+}

--- a/tests/TestCollection.h
+++ b/tests/TestCollection.h
@@ -1,0 +1,131 @@
+#pragma once
+
+#include "BaseTestClass.h"
+#include "controllers/Collection.h"
+
+#include <gtest/gtest.h>
+
+class CollectionControllerTest : public BaseTestClass<CollectionControllerTest, api::v1::Collection> {
+    void setupExpectedValues() override {
+        expectedValues["title"] = "mock title";
+        expectedValues["slug"] = "mock-slug";
+        expectedValues["description"] = "mock description";
+        expectedValues["meta_description"] = "mock meta description";
+        expectedValues["enabled"] = true;
+    }
+
+    void setupUpdatedValues() override {
+        updatedValues["title"] = "new mock title";
+        updatedValues["slug"] = "new-mock-slug";
+        updatedValues["description"] = "new mock description";
+        updatedValues["meta_description"] = "new mock meta description";
+        updatedValues["enabled"] = false;
+    }
+
+    void setupGetOneValues() override {
+        getOneValues["id"] = 1;
+        getOneValues["title"] = "Collection1";
+        getOneValues["slug"] = "collection1";
+        getOneValues["description"] = "Description1";
+        getOneValues["meta_description"] = "Meta1";
+        getOneValues["enabled"] = true;
+
+        // collection1 holds item 1 and item 2 (ordered by item.id ASC)
+        Json::Value items = Json::arrayValue;
+
+        Json::Value item1;
+        item1["id"] = 1;
+        item1["title"] = "Item1";
+        item1["slug"] = "item1";
+        item1["description"] = "Description1";
+        item1["meta_description"] = "Meta1";
+        item1["price"] = 100.0;
+        item1["shipping_profile_id"] = 1;
+        item1["enabled"] = true;
+
+        Json::Value item2;
+        item2["id"] = 2;
+        item2["title"] = "Item2";
+        item2["slug"] = "item2";
+        item2["description"] = "Description2";
+        item2["meta_description"] = "Meta2";
+        item2["price"] = 200.0;
+        item2["shipping_profile_id"] = 2;
+        item2["enabled"] = false;
+
+        items.append(item1);
+        items.append(item2);
+        getOneValues["items"] = items;
+    }
+
+    void setupGetListValues() override {
+        Json::Value data = Json::arrayValue;
+
+        // Only enabled collections are listed publicly (Collection2 is disabled)
+        Json::Value collection;
+        collection["id"] = 1;
+        collection["title"] = "Collection1";
+        collection["slug"] = "collection1";
+        collection["description"] = "Description1";
+        collection["meta_description"] = "Meta1";
+        collection["enabled"] = true;
+
+        data.append(collection);
+
+        getListValues["_page"] = 1;
+        getListValues["total"] = 1;
+        getListValues["data"] = data;
+    }
+
+public:
+    // Public getOne is slug-only: invoke with the slug, not a numeric id.
+    void testGetOneBySlug200() {
+        setupGetOneValues();
+        runAsyncTest<void>([this](auto promise) {
+            drogon::app().getLoop()->queueInLoop([this, promise]() {
+                controller.getOne(*reqPtr, getOneCallback(promise), "collection1");
+            });
+        }).get();
+    }
+
+    // A numeric id must NOT resolve publicly — it returns 404.
+    void testGetOneByNumericId404() {
+        runAsyncTest<void>([this](auto promise) {
+            drogon::app().getLoop()->queueInLoop([this, promise]() {
+                controller.getOne(*reqPtr, getOneCallback(promise, drogon::k404NotFound), "1");
+            });
+        }).get();
+    }
+};
+
+TEST_F(CollectionControllerTest, Create200) {
+    testCreate200();
+}
+
+TEST_F(CollectionControllerTest, EmptyBody400) {
+    testEmptyBody400();
+}
+
+TEST_F(CollectionControllerTest, RequiredFields400) {
+    testRequiredFields400();
+}
+
+TEST_F(CollectionControllerTest, Delete204) {
+    testDelete204();
+}
+
+TEST_F(CollectionControllerTest, Update200) {
+    testUpdate200();
+}
+
+TEST_F(CollectionControllerTest, GetOneBySlug200) {
+    testGetOneBySlug200();
+}
+
+TEST_F(CollectionControllerTest, GetOneByNumericId404) {
+    testGetOneByNumericId404();
+}
+
+TEST_F(CollectionControllerTest, GetList200) {
+    testGetList200();
+}

--- a/tests/TestCollection.h
+++ b/tests/TestCollection.h
@@ -26,8 +26,8 @@ class CollectionControllerTest : public BaseTestClass<CollectionControllerTest, 
         getOneValues["id"] = 1;
         getOneValues["title"] = "Collection1";
         getOneValues["slug"] = "collection1";
-        getOneValues["description"] = "Description1";
-        getOneValues["meta_description"] = "Meta1";
+        getOneValues["description"] = "Collection description 1";
+        getOneValues["meta_description"] = "Collection meta 1";
         getOneValues["enabled"] = true;
 
         // collection1 holds item 1 and item 2 (ordered by item.id ASC)
@@ -66,8 +66,8 @@ class CollectionControllerTest : public BaseTestClass<CollectionControllerTest, 
         collection["id"] = 1;
         collection["title"] = "Collection1";
         collection["slug"] = "collection1";
-        collection["description"] = "Description1";
-        collection["meta_description"] = "Meta1";
+        collection["description"] = "Collection description 1";
+        collection["meta_description"] = "Collection meta 1";
         collection["enabled"] = true;
 
         data.append(collection);

--- a/tests/TestCollectionItem.h
+++ b/tests/TestCollectionItem.h
@@ -1,0 +1,79 @@
+#pragma once
+
+#include "BaseTestClass.h"
+#include "controllers/CollectionItem.h"
+
+#include <gtest/gtest.h>
+
+class CollectionItemControllerTest : public BaseTestClass<CollectionItemControllerTest, api::v1::CollectionItem> {
+    void setupExpectedValues() override {
+        expectedValues["collection_id"] = 2;
+        expectedValues["item_id"] = 2;
+    }
+
+    void setupUpdatedValues() override {
+        // Must not collide with any existing (collection_id, item_id) pair in fixtures.
+        updatedValues["collection_id"] = 2;
+        updatedValues["item_id"] = 2;
+    }
+
+    void setupGetOneValues() override {
+        getOneValues["id"] = 1;
+        getOneValues["collection_id"] = 1;
+        getOneValues["item_id"] = 1;
+    }
+
+    void setupGetListValues() override {
+        getListValues["_page"] = 1;
+        getListValues["total"] = 3;
+
+        Json::Value data = Json::arrayValue;
+
+        // Default list ordering is updated_at DESC, id DESC; all three rows share
+        // the same timestamp, so the id tiebreak yields 3, 2, 1.
+        Json::Value link3;
+        link3["id"] = 3;
+        link3["collection_id"] = 2;
+        link3["item_id"] = 1;
+
+        Json::Value link2;
+        link2["id"] = 2;
+        link2["collection_id"] = 1;
+        link2["item_id"] = 2;
+
+        Json::Value link1;
+        link1["id"] = 1;
+        link1["collection_id"] = 1;
+        link1["item_id"] = 1;
+
+        data.append(link3);
+        data.append(link2);
+        data.append(link1);
+
+        getListValues["data"] = data;
+    }
+};
+
+TEST_F(CollectionItemControllerTest, EmptyBody400) {
+    testEmptyBody400();
+}
+
+TEST_F(CollectionItemControllerTest, RequiredFields400) {
+    testRequiredFields400();
+}
+
+TEST_F(CollectionItemControllerTest, GetList200) {
+    testGetList200();
+}
+
+TEST_F(CollectionItemControllerTest, testCreateItems) {
+    testCreateItems();
+}
+
+TEST_F(CollectionItemControllerTest, testUpdateItems) {
+    testUpdateItems();
+}
+
+TEST_F(CollectionItemControllerTest, testDeleteItems) {
+    testDeleteItems();
+}

--- a/tests/main.cpp
+++ b/tests/main.cpp
@@ -16,6 +16,8 @@
 #include "TestPinterestOAuth.h"
 #include "TestPin.h"
 #include "TestAiAnalyzeImage.h"
+#include "TestCollection.h"
+#include "TestCollectionItem.h"
 #include "TestCors.h"
 #include "utils/config.h"
 #include "cors.h"


### PR DESCRIPTION
## Summary

Adds **collections** of items so one item can belong to several collections (many-to-many).

- **Migrations:** `collection` table (`slug` UNIQUE, `idx_collection_enabled`) + `collection_item` junction (`FK … ON DELETE CASCADE` both sides, `UNIQUE(collection_id, item_id)`, `idx_collection_item_item_id`). Mirrors the `basket_item` M2M pattern.
- **Models:** `CollectionModel` (Item-style) and `CollectionItemModel` (BasketItem-style). Collection `getOne` embeds the collection's items via the junction.
- **`Collection` controller** (Item pattern): public `GET /api/v1/collection` (list) + public `GET /api/v1/collection/{slug}` (one collection + embedded items) + admin CRUD behind `JwtGoogleFilter`. **Public lookup is slug-only** — a numeric id returns 404, never resolves by id.
- **`CollectionItem` controller** (Tag pattern): admin-only bulk `createItems`/`updateItems`/`deleteItems` for managing membership, behind `JwtGoogleFilter`.

## Tests

Fixtures place item 1 in two collections (demonstrating M2M). New Google Test coverage:
- `Collection`: create/update/delete, public `getOne` by slug (with embedded items), **numeric id → 404**, public list (enabled-only).
- `CollectionItem`: bulk create/update/delete + list.

All 208 tests pass locally (`ctest`).

Closes #111

🤖 Generated with [Claude Code](https://claude.com/claude-code)